### PR TITLE
Add 2-minute grace period for lobby disconnections

### DIFF
--- a/src/backend/Game.cs
+++ b/src/backend/Game.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.SignalR;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace JeffopolyDeal
@@ -50,6 +51,13 @@ namespace JeffopolyDeal
         #region Connection Management
 
         private const int MaxPlayers = 5;
+        private static readonly TimeSpan LobbyGracePeriod = TimeSpan.FromMinutes(2);
+
+        /// <summary>Number of currently connected players (excludes disconnected lobby players).</summary>
+        public int ConnectedPlayerCount
+        {
+            get { lock (_lock) { return _players.Count(p => p.IsConnected); } }
+        }
 
         public async Task ConnectPlayerAsync(string connectionId, string playerName, string playerId)
         {
@@ -63,14 +71,15 @@ namespace JeffopolyDeal
                 if (_players.Any(p => p.ConnectionId == connectionId))
                     return;
 
-                if (_players.Count >= MaxPlayers)
+                if (_players.Count(p => p.IsConnected) >= MaxPlayers)
                     return;
 
                 _players.Add(new Player
                 {
                     PlayerId = playerId,
                     ConnectionId = connectionId,
-                    Name = playerName
+                    Name = playerName,
+                    IsConnected = true,
                 });
             }
 
@@ -83,13 +92,39 @@ namespace JeffopolyDeal
             lock (_lock)
             {
                 _connections.Remove(connectionId);
-                // Only remove from player list during lobby — active game players may reconnect
                 if (_phase == GamePhase.Lobby)
                 {
-                    _players.RemoveAll(p => p.ConnectionId == connectionId);
+                    // Mark as disconnected instead of removing — give them a grace period
+                    var player = _players.FirstOrDefault(p => p.ConnectionId == connectionId);
+                    if (player != null)
+                    {
+                        player.IsConnected = false;
+                        player.DisconnectedAt = DateTime.UtcNow;
+                    }
                 }
             }
             await BroadcastGameStateAsync();
+        }
+
+        /// <summary>
+        /// Remove lobby players whose grace period has expired.
+        /// Returns true if any players were removed.
+        /// </summary>
+        public async Task<bool> CleanupExpiredLobbyPlayersAsync()
+        {
+            bool removed = false;
+            lock (_lock)
+            {
+                if (_phase != GamePhase.Lobby) return false;
+                var now = DateTime.UtcNow;
+                removed = _players.RemoveAll(p =>
+                    !p.IsConnected &&
+                    p.DisconnectedAt.HasValue &&
+                    (now - p.DisconnectedAt.Value) >= LobbyGracePeriod) > 0;
+            }
+            if (removed)
+                await BroadcastGameStateAsync();
+            return removed;
         }
 
         /// <summary>Whether the game can be safely deleted (no connections AND in lobby or game over).</summary>
@@ -110,14 +145,25 @@ namespace JeffopolyDeal
                     _connections.Remove(oldConnectionId);
                     _connections[newConnectionId] = true;
                     player.ConnectionId = newConnectionId;
+                    player.IsConnected = true;
+                    player.DisconnectedAt = null;
                     found = true;
                 }
                 else if (_phase == GamePhase.Lobby)
                 {
-                    // Player not found — join as new player in lobby
-                    _connections[newConnectionId] = true;
-                    _players.Add(new Player { PlayerId = playerId, ConnectionId = newConnectionId, Name = playerName });
-                    found = true;
+                    // Player not found — join as new player in lobby (if room)
+                    if (_players.Count(p => p.IsConnected) < MaxPlayers)
+                    {
+                        _connections[newConnectionId] = true;
+                        _players.Add(new Player
+                        {
+                            PlayerId = playerId,
+                            ConnectionId = newConnectionId,
+                            Name = playerName,
+                            IsConnected = true,
+                        });
+                        found = true;
+                    }
                 }
             }
 
@@ -138,6 +184,10 @@ namespace JeffopolyDeal
             lock (_lock)
             {
                 int minPlayers = allowSinglePlayer ? 1 : 2;
+
+                // Remove disconnected players before starting
+                _players.RemoveAll(p => !p.IsConnected);
+
                 if (_phase != GamePhase.Lobby || _players.Count < minPlayers)
                     return;
 
@@ -1370,6 +1420,7 @@ namespace JeffopolyDeal
                     ConnectionId = player.ConnectionId,
                     Name = player.Name,
                     HandCount = player.Hand.Count,
+                    IsConnected = player.IsConnected,
                     Bank = player.Bank.ToList(),
                     UnboundWilds = player.UnboundWilds.ToList(),
                     CompletedSetCount = player.CompletedSetCount,
@@ -1445,9 +1496,11 @@ namespace JeffopolyDeal
                 playersCopy = _players.ToList();
             }
 
-            // Send personalized state to each player (with their own hand)
+            // Send personalized state to each connected player (with their own hand)
             foreach (var player in playersCopy)
             {
+                if (!player.IsConnected) continue;
+
                 GameState state;
                 lock (_lock)
                 {

--- a/src/backend/GameCache.cs
+++ b/src/backend/GameCache.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.SignalR;
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace JeffopolyDeal
@@ -16,7 +17,9 @@ namespace JeffopolyDeal
         private readonly IHubContext<GameHub> _hubContext;
         private readonly ConcurrentDictionary<string, string> _connectionToGame = new();
         private readonly ConcurrentDictionary<string, Game> _games = new();
+        private readonly ConcurrentDictionary<string, CancellationTokenSource> _cleanupTimers = new();
         private readonly Random _rng = new();
+        private static readonly TimeSpan LobbyCleanupDelay = TimeSpan.FromMinutes(2);
 
         public GameCache(IHubContext<GameHub> hubContext)
         {
@@ -50,6 +53,7 @@ namespace JeffopolyDeal
             if (!_games.TryGetValue(gameCode, out var game))
                 return;
 
+            CancelCleanupTimer(gameCode);
             _connectionToGame[connectionId] = gameCode;
             await game.ConnectPlayerAsync(connectionId, playerName, playerId);
         }
@@ -64,6 +68,7 @@ namespace JeffopolyDeal
             if (!_games.TryGetValue(gameCode, out var game))
                 return false;
 
+            CancelCleanupTimer(gameCode);
             _connectionToGame[connectionId] = gameCode;
             return await game.ReconnectPlayerAsync(connectionId, playerName, playerId);
         }
@@ -129,11 +134,60 @@ namespace JeffopolyDeal
             if (_games.TryGetValue(gameCode, out var game))
             {
                 await game.RemovePlayerAsync(connectionId);
-                // Only delete the game if it's safe (lobby or game over with no connections)
+
                 if (game.CanBeDeleted)
                 {
-                    _games.TryRemove(gameCode, out _);
+                    // Schedule delayed cleanup — gives disconnected lobby players time to rejoin
+                    ScheduleGameCleanup(gameCode);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Schedule a delayed cleanup for a lobby game. Cancels any existing timer for this game.
+        /// </summary>
+        private void ScheduleGameCleanup(string gameCode)
+        {
+            // Cancel any existing timer for this game
+            CancelCleanupTimer(gameCode);
+
+            var cts = new CancellationTokenSource();
+            _cleanupTimers[gameCode] = cts;
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(LobbyCleanupDelay, cts.Token);
+                }
+                catch (TaskCanceledException)
+                {
+                    return; // Timer was cancelled (player reconnected)
+                }
+
+                // Timer fired — clean up expired players first
+                if (_games.TryGetValue(gameCode, out var game))
+                {
+                    await game.CleanupExpiredLobbyPlayersAsync();
+
+                    // Re-check: if still deletable, remove the game
+                    if (game.CanBeDeleted)
+                    {
+                        _games.TryRemove(gameCode, out _);
+                    }
+                }
+
+                _cleanupTimers.TryRemove(gameCode, out _);
+            });
+        }
+
+        /// <summary>Cancel a pending cleanup timer for a game (e.g., when a player reconnects).</summary>
+        private void CancelCleanupTimer(string gameCode)
+        {
+            if (_cleanupTimers.TryRemove(gameCode, out var cts))
+            {
+                cts.Cancel();
+                cts.Dispose();
             }
         }
 

--- a/src/backend/Models/GameState.cs
+++ b/src/backend/Models/GameState.cs
@@ -147,6 +147,9 @@ namespace JeffopolyDeal.Models
         public string Name { get; set; } = "";
         public int HandCount { get; set; }
 
+        /// <summary>Whether this player is currently connected.</summary>
+        public bool IsConnected { get; set; } = true;
+
         /// <summary>Only populated for the requesting player.</summary>
         public List<Card>? Hand { get; set; }
 

--- a/src/backend/Models/Player.cs
+++ b/src/backend/Models/Player.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -12,6 +13,12 @@ namespace JeffopolyDeal.Models
         public string PlayerId { get; set; } = "";
         public string ConnectionId { get; set; } = "";
         public string Name { get; set; } = "";
+
+        /// <summary>Whether this player currently has an active connection.</summary>
+        public bool IsConnected { get; set; } = true;
+
+        /// <summary>When the player disconnected (null if connected).</summary>
+        public DateTime? DisconnectedAt { get; set; }
 
         /// <summary>Cards in the player's hand (hidden from other players).</summary>
         public List<Card> Hand { get; set; } = new();

--- a/src/web/Types.ts
+++ b/src/web/Types.ts
@@ -49,6 +49,7 @@ export interface PlayerState {
     connectionId: string;
     name: string;
     handCount: number;
+    isConnected: boolean;
     hand?: Card[];
     bank: Card[];
     propertySets: PropertySetState[];

--- a/src/web/pages/gamePage/GamePage.tsx
+++ b/src/web/pages/gamePage/GamePage.tsx
@@ -227,6 +227,10 @@ export function GamePage({ gameCode, playerName, playerId, isRejoin, onGameCodeR
 
     // Lobby
     if (state.phase === "Lobby") {
+        const connectedCount = state.players.filter(p => p.isConnected).length;
+        // Allow any connected player to start if the original host is disconnected
+        const canStart = isCreator || (state.players[0] && !state.players[0].isConnected);
+
         return (
             <div className="gamePage">
                 <div className="lobby">
@@ -235,14 +239,15 @@ export function GamePage({ gameCode, playerName, playerId, isRejoin, onGameCodeR
                         Game Code: <span className="code">{state.gameCode}</span>
                     </div>
                     <div className="playerList">
-                        <h3>Players ({state.players.length}/5)</h3>
+                        <h3>Players ({connectedCount}/5)</h3>
                         {state.players.map((p) => (
-                            <div key={p.connectionId} className="playerName">
-                                {p.name} {p.connectionId === myConnectionId ? "(you)" : ""}
+                            <div key={p.playerId} className={`playerName${p.isConnected ? "" : " disconnected"}`}>
+                                {p.name} {p.playerId === playerId ? "(you)" : ""}
+                                {!p.isConnected && <span className="disconnectedLabel"> (reconnecting...)</span>}
                             </div>
                         ))}
                     </div>
-                    {isCreator && (
+                    {canStart && (
                         <button
                             className="primary"
                             onClick={() => client?.startGame(
@@ -251,12 +256,12 @@ export function GamePage({ gameCode, playerName, playerId, isRejoin, onGameCodeR
                                 Debug.isFlagSet(DebugFlags.PopulatedBoards),
                                 Debug.isFlagSet(DebugFlags.PlayVsAi) || Debug.isFlagSet(DebugFlags.PopulatedBoards)
                             )}
-                            disabled={state.players.length < minPlayers}
+                            disabled={connectedCount < minPlayers}
                         >
-                            Start Game {state.players.length < minPlayers ? `(need ${minPlayers}+ players)` : ""}
+                            Start Game {connectedCount < minPlayers ? `(need ${minPlayers}+ players)` : ""}
                         </button>
                     )}
-                    {!isCreator && <p className="waitingText">Waiting for host to start...</p>}
+                    {!canStart && <p className="waitingText">Waiting for host to start...</p>}
                     <button className="secondary" onClick={onLeave}>Exit Game</button>
                 </div>
             </div>

--- a/src/web/pages/gamePage/styles/game.css
+++ b/src/web/pages/gamePage/styles/game.css
@@ -77,6 +77,16 @@
     font-size: 0.85rem;
 }
 
+.playerName.disconnected {
+    opacity: 0.45;
+}
+
+.disconnectedLabel {
+    color: #f5a623;
+    font-size: 0.75rem;
+    font-style: italic;
+}
+
 .waitingText {
     color: #888;
     font-style: italic;


### PR DESCRIPTION
Fixes mobile disconnect issue where the game would disappear when a player's connection dropped in the lobby.

## Changes
- **Grace period**: Disconnected lobby players get 2 minutes to reconnect instead of being immediately removed
- **Visual feedback**: Disconnected players shown greyed out with "reconnecting..." label
- **Host transfer**: If the host disconnects, any connected player can start the game
- **Timer management**: Cleanup timers are cancellable and reset on join/rejoin to prevent race conditions
- **Start game**: Only counts connected players; purges disconnected players before starting