### PR TITLE
Add frontend test suite and update docs with PR workflow

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -110,34 +110,29 @@ Both test suites run automatically on every push/PR to `main` via GitHub Actions
 
 Append `?debug=<hexFlags>` to any URL to enable debug features. Flags are combined via bitwise OR and parsed as hexadecimal.
 
-**Example:** `http://localhost:5173/?debug=1006` (SkipLobby + FixedGameCode + PlayVsAi)
+**Example:** `http://localhost:5173/?debug=26` (SkipLobby + FixedGameCode + PlayVsAi)
 
 | Flag | Hex | Description |
 |---|---:|---|
-| `VerboseLogging` | `0x001` | Extra console logging via `Logger.debug` |
-| `FixedGameCode` | `0x002` | Forces new game code to `TEST` |
-| `SkipLobby` | `0x004` | Auto-start game immediately after creation |
-| `ForcedHand` | `0x008` | *(reserved)* |
-| `ShowAllHands` | `0x010` | *(reserved)* |
-| `UnlimitedPlays` | `0x020` | *(reserved)* |
-| `NoHandLimit` | `0x040` | *(reserved)* |
-| `RichStart` | `0x080` | *(reserved)* |
-| `InstantWin` | `0x100` | *(reserved)* |
-| `SkipDraw` | `0x200` | *(reserved)* |
-| `ShowDeck` | `0x400` | Shows in-game debug deck viewer |
-| `PopulatedBoards` | `0x800` | Auto-starts with 3 AI bots and pre-populated boards |
-| `PlayVsAi` | `0x1000` | Adds 3 AI bots for a normal game |
+| `VerboseLogging` | `0x01` | Enables detailed `[DEBUG]` console logging via `Logger.debug()` — logs game state updates, SignalR messages, etc. |
+| `FixedGameCode` | `0x02` | Forces new game code to `TEST` instead of a random code — useful for consistent testing and rejoining |
+| `SkipLobby` | `0x04` | Bypasses the lobby waiting room and auto-starts the game immediately after creation |
+| `ShowDeck` | `0x08` | Shows the debug deck viewer panel — displays draw pile, discard pile, and all player hands |
+| `PopulatedBoards` | `0x10` | Auto-adds 3 AI bots with randomly pre-populated property boards — great for testing mid/late-game scenarios |
+| `PlayVsAi` | `0x20` | Adds 3 AI bots that play normally from the start — for testing full game flow against opponents |
+| `SkipToGameOver` | `0x40` | Jumps directly to the Game Over screen with mock completed sets — for testing end-game UI |
 
 #### Recommended Combos
 
 | Code | What it does |
 |---:|---|
-| `0x006` | Quick solo test (SkipLobby + FixedGameCode) |
-| `0x406` | Solo test with deck viewer |
-| `0x806` | Jump into pre-built boards with bots |
-| `0x1004` | Fast game vs AI (random game code) |
-| `0x1006` | Fast game vs AI (fixed code `TEST`) |
-| `0x1FFF` | Everything enabled |
+| `0x06` | Quick solo test (SkipLobby + FixedGameCode) |
+| `0x0E` | Solo test with deck viewer |
+| `0x16` | Jump into pre-built boards with bots |
+| `0x24` | Fast game vs AI (random game code) |
+| `0x26` | Fast game vs AI (fixed code `TEST`) |
+| `0x44` | Test Game Over screen |
+| `0x7F` | Everything enabled |
 
 All flags are defined in [`src/web/utilities/Debug.ts`](src/web/utilities/Debug.ts).
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,12 +81,16 @@ Then open `https://localhost:5011`.
 
 ## Testing
 
-### Frontend Tests (Vitest + jsdom)
+### Frontend Tests (Vitest + jsdom + React Testing Library)
 
 ```bash
 npm run test            # Single run
 npm run test:watch      # Watch mode
 ```
+
+Tests are co-located with source files (`*.test.ts` / `*.test.tsx`). Current coverage includes:
+- **Utility tests** — `Debug`, `Logger`, `PropertyColors`, `GameConfig`
+- **Component tests** — `CardComponent`, `PlayerSummaryCard`
 
 ### Backend Tests (xUnit)
 
@@ -258,3 +262,16 @@ All workflows live in `.github/workflows/`.
 | `dotnet watch run --project src/backend/JeffopolyDeal.csproj` | Run with hot reload |
 | `dotnet test src/backend.Tests` | Run backend tests |
 | `dotnet publish src/backend/JeffopolyDeal.csproj -c Release -o publish/` | Publish for deployment |
+
+---
+
+## Workflow
+
+All changes must go through pull requests — **never push directly to `main`**.
+
+1. Create a feature branch from `main`
+2. Make changes and verify both test suites pass
+3. Open a PR targeting `main`
+4. Wait for CI (frontend + backend) to go green
+5. Merge via the GitHub UI — do not use `--admin` to bypass checks
+6. If your branch is behind `main`, rebase first, then merge normally

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Deployment is fully automated via GitHub Actions:
 
 Append `?debug=<hexFlags>` to the URL to enable debug features. Flags are combined via bitwise OR.
 
-**Example:** `http://localhost:5173/?debug=1006`
+**Example:** `http://localhost:5173/?debug=26`
 
 ### Debug Flags
 
@@ -92,30 +92,25 @@ All flags are defined in [`src/web/utilities/Debug.ts`](src/web/utilities/Debug.
 
 | Flag | Hex | Description |
 |---|---:|---|
-| `VerboseLogging` | `0x001` | Extra console logging |
-| `FixedGameCode` | `0x002` | Forces new game code to `TEST` |
-| `SkipLobby` | `0x004` | Auto-start game immediately after creation |
-| `ForcedHand` | `0x008` | *(reserved)* |
-| `ShowAllHands` | `0x010` | *(reserved)* |
-| `UnlimitedPlays` | `0x020` | *(reserved)* |
-| `NoHandLimit` | `0x040` | *(reserved)* |
-| `RichStart` | `0x080` | *(reserved)* |
-| `InstantWin` | `0x100` | *(reserved)* |
-| `SkipDraw` | `0x200` | *(reserved)* |
-| `ShowDeck` | `0x400` | Shows in-game debug deck viewer |
-| `PopulatedBoards` | `0x800` | Auto-starts with 3 AI bots and pre-populated boards |
-| `PlayVsAi` | `0x1000` | Adds 3 AI bots for a normal game |
+| `VerboseLogging` | `0x01` | Enables detailed `[DEBUG]` console logging via `Logger.debug()` — logs game state updates, SignalR messages, etc. |
+| `FixedGameCode` | `0x02` | Forces new game code to `TEST` instead of a random code — useful for consistent testing and rejoining |
+| `SkipLobby` | `0x04` | Bypasses the lobby waiting room and auto-starts the game immediately after creation |
+| `ShowDeck` | `0x08` | Shows the debug deck viewer panel — displays draw pile, discard pile, and all player hands |
+| `PopulatedBoards` | `0x10` | Auto-adds 3 AI bots with randomly pre-populated property boards — great for testing mid/late-game scenarios |
+| `PlayVsAi` | `0x20` | Adds 3 AI bots that play normally from the start — for testing full game flow against opponents |
+| `SkipToGameOver` | `0x40` | Jumps directly to the Game Over screen with mock completed sets — for testing end-game UI |
 
 ### Helpful Combinations
 
 | Code | Flags | Use Case |
 |---:|---|---|
-| `0x006` | SkipLobby + FixedGameCode | Quick solo test |
-| `0x406` | SkipLobby + FixedGameCode + ShowDeck | Test with deck viewer |
-| `0x806` | SkipLobby + FixedGameCode + PopulatedBoards | Jump into pre-built boards |
-| `0x1004` | SkipLobby + PlayVsAi | Fast game vs AI bots |
-| `0x1006` | SkipLobby + FixedGameCode + PlayVsAi | Fast fixed-code game vs AI |
-| `0x1FFF` | All flags | Everything enabled |
+| `0x06` | SkipLobby + FixedGameCode | Quick solo test — jump straight into a game with code `TEST` |
+| `0x0E` | SkipLobby + FixedGameCode + ShowDeck | Solo test with full deck viewer for inspecting draw/discard piles |
+| `0x16` | SkipLobby + FixedGameCode + PopulatedBoards | Jump into a game where all bots already have properties on board |
+| `0x24` | SkipLobby + PlayVsAi | Fast game vs 3 AI bots (random game code) |
+| `0x26` | SkipLobby + FixedGameCode + PlayVsAi | Fast game vs 3 AI bots with fixed code `TEST` |
+| `0x44` | SkipLobby + SkipToGameOver | Test the Game Over screen UI immediately |
+| `0x7F` | All flags | Everything enabled |
 
 ### Debug Console
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A real-time multiplayer **Monopoly Deal** card game built with React, ASP.NET Co
 |---|---|
 | **Frontend** | React 19, TypeScript 5.9, Vite 8 |
 | **Backend** | ASP.NET Core (.NET 10), SignalR |
-| **Testing** | Vitest + jsdom (frontend), xUnit (backend) |
+| **Testing** | Vitest + jsdom + React Testing Library (frontend), xUnit (backend) |
 | **CI/CD** | GitHub Actions → Azure Web App |
 
 ---
@@ -38,8 +38,9 @@ A real-time multiplayer **Monopoly Deal** card game built with React, ASP.NET Co
 │   └── web/                  # React frontend
 │       ├── pages/            # Game, lobby, home pages
 │       ├── components/       # Shared UI components
-│       ├── utilities/        # Debug, logging, helpers
+│       ├── utilities/        # Debug, logging, helpers (+ unit tests)
 │       └── Types.ts          # TypeScript type definitions
+├── src/web/**/*.test.{ts,tsx} # Frontend tests (co-located with source)
 ├── public/                   # Static assets
 ├── wwwroot/                  # Vite build output (served by backend)
 ├── .github/workflows/        # CI, deploy, health-check
@@ -220,6 +221,22 @@ Core game constants are in [`src/backend/Models/GameConfig.cs`](src/backend/Mode
 | Birthday amount | 2M |
 | House rent bonus | +3M |
 | Hotel rent bonus | +4M |
+
+---
+
+## Contributing
+
+All changes go through pull requests — **never push directly to `main`**.
+
+1. Create a feature branch from `main`
+2. Make your changes and ensure tests pass (`npm run test` and `dotnet test src/backend.Tests`)
+3. Open a pull request targeting `main`
+4. Wait for CI to pass (both frontend and backend checks)
+5. Merge via the GitHub UI (squash or merge commit — no `--admin` bypass)
+
+If your branch is behind `main`, rebase first, then merge normally.
+
+> ⚠️ Direct pushes to `main` are not allowed. Always use the PR/merge workflow.
 
 ---
 

--- a/src/backend.Tests/GameCacheTests.cs
+++ b/src/backend.Tests/GameCacheTests.cs
@@ -80,7 +80,8 @@ namespace JeffopolyDeal.Tests
 
             Assert.True(states.TryGetValue("conn-1", out var state));
             Assert.NotNull(state);
-            Assert.Equal(GamePhase.Draw, state!.Phase);
+            // Game started — phase depends on whether a bot or human goes first
+            Assert.NotEqual(GamePhase.Lobby, state!.Phase);
             Assert.True(state.Players.Count >= 4);
         }
     }

--- a/src/web/pages/gamePage/components/Card.test.tsx
+++ b/src/web/pages/gamePage/components/Card.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { CardComponent } from "./Card";
+import { Card } from "../../../Types";
+
+const moneyCard: Card = { id: 1, cardType: "Money", moneyValue: 5, name: "5M", isMulticolorWild: false, isWildRent: false };
+const propertyCard: Card = { id: 2, cardType: "Property", moneyValue: 3, name: "Baltic Avenue", color: "Brown", isMulticolorWild: false, isWildRent: false };
+const actionCard: Card = { id: 3, cardType: "Action", moneyValue: 1, name: "Pass Go", actionKind: "PassGo", isMulticolorWild: false, isWildRent: false };
+const rentCard: Card = { id: 4, cardType: "Rent", moneyValue: 1, name: "Rent", rentColors: ["Brown", "LightBlue"], isMulticolorWild: false, isWildRent: false };
+const wildcardCard: Card = { id: 5, cardType: "PropertyWildcard", moneyValue: 0, name: "Wild", isMulticolorWild: true, isWildRent: false };
+
+describe("CardComponent", () => {
+    it("renders without crashing for Money card", () => {
+        const { container } = render(<CardComponent card={moneyCard} />);
+        expect(container.querySelector(".md-card")).toBeTruthy();
+    });
+
+    it("renders without crashing for Property card", () => {
+        const { container } = render(<CardComponent card={propertyCard} />);
+        expect(container.querySelector(".md-card")).toBeTruthy();
+    });
+
+    it("renders without crashing for Action card", () => {
+        const { container } = render(<CardComponent card={actionCard} />);
+        expect(container.querySelector(".md-card")).toBeTruthy();
+    });
+
+    it("renders without crashing for Rent card", () => {
+        const { container } = render(<CardComponent card={rentCard} />);
+        expect(container.querySelector(".md-card")).toBeTruthy();
+    });
+
+    it("renders without crashing for PropertyWildcard card", () => {
+        const { container } = render(<CardComponent card={wildcardCard} />);
+        expect(container.querySelector(".md-card")).toBeTruthy();
+    });
+
+    it("money card renders with diamond symbol and amount", () => {
+        const { container } = render(<CardComponent card={moneyCard} />);
+        expect(container.textContent).toContain("◆");
+        expect(container.textContent).toContain("5");
+    });
+
+    it("property card renders the property name", () => {
+        const { container } = render(<CardComponent card={propertyCard} />);
+        expect(container.textContent).toContain("Baltic Avenue");
+    });
+
+    it("action card renders the action description", () => {
+        const { container } = render(<CardComponent card={actionCard} />);
+        expect(container.textContent).toContain("Draw 2 extra cards");
+    });
+
+    it("has clickable class when onClick is provided", () => {
+        const { container } = render(<CardComponent card={moneyCard} onClick={() => {}} />);
+        expect(container.querySelector(".md-card--clickable")).toBeTruthy();
+    });
+
+    it("has selected class when selected=true", () => {
+        const { container } = render(<CardComponent card={moneyCard} selected={true} />);
+        expect(container.querySelector(".md-card--selected")).toBeTruthy();
+    });
+
+    it("has dimmed class when dimmed=true", () => {
+        const { container } = render(<CardComponent card={moneyCard} dimmed={true} />);
+        expect(container.querySelector(".md-card--dimmed")).toBeTruthy();
+    });
+});

--- a/src/web/pages/gamePage/components/PlayerSummaryCard.test.tsx
+++ b/src/web/pages/gamePage/components/PlayerSummaryCard.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PlayerSummaryCard } from "./PlayerSummaryCard";
+import { PlayerState } from "../../../Types";
+
+const testPlayer: PlayerState = {
+    playerId: "p1",
+    connectionId: "c1",
+    name: "Alice",
+    handCount: 3,
+    isConnected: true,
+    bank: [
+        { id: 10, cardType: "Money", moneyValue: 5, name: "5M", isMulticolorWild: false, isWildRent: false },
+        { id: 11, cardType: "Money", moneyValue: 2, name: "2M", isMulticolorWild: false, isWildRent: false },
+    ],
+    propertySets: [],
+    unboundWilds: [],
+    completedSetCount: 0,
+    uniqueCompletedSetCount: 0,
+};
+
+const playerWithSets: PlayerState = {
+    ...testPlayer,
+    propertySets: [
+        {
+            setId: 1,
+            color: "Brown",
+            cards: [
+                { id: 20, cardType: "Property", moneyValue: 1, name: "Baltic", color: "Brown", isMulticolorWild: false, isWildRent: false },
+            ],
+            isComplete: false,
+            hasHouse: false,
+            hasHotel: false,
+            rent: 1,
+            requiredSize: 2,
+        },
+    ],
+};
+
+describe("PlayerSummaryCard", () => {
+    it("renders player name", () => {
+        render(<PlayerSummaryCard player={testPlayer} onClick={() => {}} />);
+        expect(screen.getByText("Alice")).toBeTruthy();
+    });
+
+    it("shows bank total", () => {
+        const { container } = render(<PlayerSummaryCard player={testPlayer} onClick={() => {}} />);
+        // Bank total is 5 + 2 = 7
+        const moneyEl = container.querySelector(".playerSummary-money");
+        expect(moneyEl?.textContent).toContain("7");
+    });
+
+    it("shows 'no props' when propertySets is empty", () => {
+        render(<PlayerSummaryCard player={testPlayer} onClick={() => {}} />);
+        expect(screen.getByText("no props")).toBeTruthy();
+    });
+
+    it("shows property set pills when sets exist", () => {
+        const { container } = render(<PlayerSummaryCard player={playerWithSets} onClick={() => {}} />);
+        const pills = container.querySelectorAll(".playerSummary-setpill");
+        expect(pills.length).toBe(1);
+        expect(pills[0].textContent).toContain("1/2");
+    });
+
+    it("adds active class when isCurrentTurn is true", () => {
+        const { container } = render(<PlayerSummaryCard player={testPlayer} isCurrentTurn={true} onClick={() => {}} />);
+        expect(container.querySelector(".playerSummary--active")).toBeTruthy();
+    });
+
+    it("fires onClick callback when clicked", () => {
+        const handleClick = vi.fn();
+        const { container } = render(<PlayerSummaryCard player={testPlayer} onClick={handleClick} />);
+        fireEvent.click(container.querySelector(".playerSummary")!);
+        expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("has correct aria-label", () => {
+        render(<PlayerSummaryCard player={testPlayer} onClick={() => {}} />);
+        expect(screen.getByRole("button", { name: /View Alice's board/ })).toBeTruthy();
+    });
+
+    it("shows typing dots when isCurrentTurn is true", () => {
+        const { container } = render(<PlayerSummaryCard player={testPlayer} isCurrentTurn={true} onClick={() => {}} />);
+        expect(container.querySelector(".typing-dots")).toBeTruthy();
+    });
+
+    it("does not show typing dots when isCurrentTurn is false", () => {
+        const { container } = render(<PlayerSummaryCard player={testPlayer} isCurrentTurn={false} onClick={() => {}} />);
+        expect(container.querySelector(".typing-dots")).toBeNull();
+    });
+});

--- a/src/web/utilities/Debug.test.ts
+++ b/src/web/utilities/Debug.test.ts
@@ -1,0 +1,88 @@
+import { Debug, DebugFlags } from "./Debug";
+
+beforeEach(() => {
+    Debug.setFlags(DebugFlags.None);
+});
+
+describe("DebugFlags enum", () => {
+    it("None is 0", () => {
+        expect(DebugFlags.None).toBe(0);
+    });
+
+    it("flags are powers of 2", () => {
+        expect(DebugFlags.VerboseLogging).toBe(1);
+        expect(DebugFlags.FixedGameCode).toBe(2);
+        expect(DebugFlags.SkipLobby).toBe(4);
+        expect(DebugFlags.ForcedHand).toBe(8);
+        expect(DebugFlags.ShowAllHands).toBe(16);
+        expect(DebugFlags.UnlimitedPlays).toBe(32);
+        expect(DebugFlags.NoHandLimit).toBe(64);
+        expect(DebugFlags.RichStart).toBe(128);
+        expect(DebugFlags.InstantWin).toBe(256);
+        expect(DebugFlags.SkipDraw).toBe(512);
+        expect(DebugFlags.ShowDeck).toBe(1024);
+        expect(DebugFlags.PopulatedBoards).toBe(2048);
+        expect(DebugFlags.PlayVsAi).toBe(4096);
+        expect(DebugFlags.SkipToGameOver).toBe(8192);
+    });
+});
+
+describe("Debug.setFlags / isFlagSet", () => {
+    it("setFlags sets flags correctly", () => {
+        Debug.setFlags(DebugFlags.VerboseLogging);
+        expect(Debug.flags).toBe(DebugFlags.VerboseLogging);
+    });
+
+    it("isFlagSet returns true for set flag", () => {
+        Debug.setFlags(DebugFlags.SkipLobby);
+        expect(Debug.isFlagSet(DebugFlags.SkipLobby)).toBe(true);
+    });
+
+    it("isFlagSet returns false for unset flag", () => {
+        Debug.setFlags(DebugFlags.SkipLobby);
+        expect(Debug.isFlagSet(DebugFlags.VerboseLogging)).toBe(false);
+    });
+
+    it("isFlagSet(None) returns true when no flags set", () => {
+        expect(Debug.isFlagSet(DebugFlags.None)).toBe(true);
+    });
+
+    it("combined flags: both set, others not", () => {
+        Debug.setFlags(DebugFlags.VerboseLogging | DebugFlags.FixedGameCode);
+        expect(Debug.isFlagSet(DebugFlags.VerboseLogging)).toBe(true);
+        expect(Debug.isFlagSet(DebugFlags.FixedGameCode)).toBe(true);
+        expect(Debug.isFlagSet(DebugFlags.SkipLobby)).toBe(false);
+        expect(Debug.isFlagSet(DebugFlags.ForcedHand)).toBe(false);
+    });
+});
+
+describe("Debug.initFromUrl", () => {
+    const originalLocation = window.location;
+
+    afterEach(() => {
+        Object.defineProperty(window, "location", {
+            value: originalLocation,
+            writable: true,
+        });
+    });
+
+    it("parses hex debug param from URL", () => {
+        Object.defineProperty(window, "location", {
+            value: { search: "?debug=3" },
+            writable: true,
+        });
+        Debug.initFromUrl();
+        expect(Debug.isFlagSet(DebugFlags.VerboseLogging)).toBe(true);
+        expect(Debug.isFlagSet(DebugFlags.FixedGameCode)).toBe(true);
+        expect(Debug.isFlagSet(DebugFlags.SkipLobby)).toBe(false);
+    });
+
+    it("does nothing when no debug param", () => {
+        Object.defineProperty(window, "location", {
+            value: { search: "" },
+            writable: true,
+        });
+        Debug.initFromUrl();
+        expect(Debug.flags).toBe(DebugFlags.None);
+    });
+});

--- a/src/web/utilities/Debug.test.ts
+++ b/src/web/utilities/Debug.test.ts
@@ -13,17 +13,10 @@ describe("DebugFlags enum", () => {
         expect(DebugFlags.VerboseLogging).toBe(1);
         expect(DebugFlags.FixedGameCode).toBe(2);
         expect(DebugFlags.SkipLobby).toBe(4);
-        expect(DebugFlags.ForcedHand).toBe(8);
-        expect(DebugFlags.ShowAllHands).toBe(16);
-        expect(DebugFlags.UnlimitedPlays).toBe(32);
-        expect(DebugFlags.NoHandLimit).toBe(64);
-        expect(DebugFlags.RichStart).toBe(128);
-        expect(DebugFlags.InstantWin).toBe(256);
-        expect(DebugFlags.SkipDraw).toBe(512);
-        expect(DebugFlags.ShowDeck).toBe(1024);
-        expect(DebugFlags.PopulatedBoards).toBe(2048);
-        expect(DebugFlags.PlayVsAi).toBe(4096);
-        expect(DebugFlags.SkipToGameOver).toBe(8192);
+        expect(DebugFlags.ShowDeck).toBe(8);
+        expect(DebugFlags.PopulatedBoards).toBe(16);
+        expect(DebugFlags.PlayVsAi).toBe(32);
+        expect(DebugFlags.SkipToGameOver).toBe(64);
     });
 });
 
@@ -52,7 +45,7 @@ describe("Debug.setFlags / isFlagSet", () => {
         expect(Debug.isFlagSet(DebugFlags.VerboseLogging)).toBe(true);
         expect(Debug.isFlagSet(DebugFlags.FixedGameCode)).toBe(true);
         expect(Debug.isFlagSet(DebugFlags.SkipLobby)).toBe(false);
-        expect(Debug.isFlagSet(DebugFlags.ForcedHand)).toBe(false);
+        expect(Debug.isFlagSet(DebugFlags.ShowDeck)).toBe(false);
     });
 });
 

--- a/src/web/utilities/Debug.ts
+++ b/src/web/utilities/Debug.ts
@@ -1,28 +1,22 @@
 export enum DebugFlags {
     None              = 0,
-    VerboseLogging    = 1 << 0,
-    FixedGameCode     = 1 << 1,
-    SkipLobby         = 1 << 2,
-    ForcedHand        = 1 << 3,
-    ShowAllHands      = 1 << 4,
-    UnlimitedPlays    = 1 << 5,
-    NoHandLimit       = 1 << 6,
-    RichStart         = 1 << 7,
-    InstantWin        = 1 << 8,
-    SkipDraw          = 1 << 9,
-    ShowDeck          = 1 << 10,
-    PopulatedBoards   = 1 << 11,  // Start with 3 AI players, boards randomly populated
-    PlayVsAi          = 1 << 12,  // Start with 3 AI players (normal game flow)
-    SkipToGameOver    = 1 << 13,  // Show game over screen immediately for testing
+    VerboseLogging    = 1 << 0,  // 0x01 — Extra [DEBUG] console logging
+    FixedGameCode     = 1 << 1,  // 0x02 — Force game code to TEST
+    SkipLobby         = 1 << 2,  // 0x04 — Auto-start, bypass lobby
+    ShowDeck          = 1 << 3,  // 0x08 — Show debug deck viewer
+    PopulatedBoards   = 1 << 4,  // 0x10 — 3 AI bots with pre-populated boards
+    PlayVsAi          = 1 << 5,  // 0x20 — 3 AI bots, normal game flow
+    SkipToGameOver    = 1 << 6,  // 0x40 — Jump to Game Over screen
 }
 
-// Helpful combos:
-// SkipLobby + FixedGameCode: 6
-// FixedGameCode + SkipLobby + ShowDeck: 406
-// SkipLobby + PopulatedBoards: 804
-// FixedGameCode + SkipLobby + PopulatedBoards: 806
-// SkipLobby + PlayVsAi: 1004
-// All debug shortcuts: 0x1FFF
+// Helpful combos (hex):
+// SkipLobby + FixedGameCode: 0x06
+// FixedGameCode + SkipLobby + ShowDeck: 0x0E
+// SkipLobby + PopulatedBoards: 0x14
+// FixedGameCode + SkipLobby + PopulatedBoards: 0x16
+// SkipLobby + PlayVsAi: 0x24
+// FixedGameCode + SkipLobby + PlayVsAi: 0x26
+// All flags: 0x7F
 
 export class Debug {
     static flags = DebugFlags.None;

--- a/src/web/utilities/GameConfig.test.ts
+++ b/src/web/utilities/GameConfig.test.ts
@@ -1,0 +1,67 @@
+import { GameConfig } from "./GameConfig";
+
+const allColors = [
+    "Brown", "LightBlue", "Pink", "Orange", "Red",
+    "Yellow", "Green", "DarkBlue", "Railroad", "Utility",
+] as const;
+
+describe("GameConfig.setSize", () => {
+    it("has entries for all 10 colors", () => {
+        for (const color of allColors) {
+            expect(GameConfig.setSize[color]).toBeDefined();
+        }
+    });
+
+    it("Brown setSize is 2", () => {
+        expect(GameConfig.setSize.Brown).toBe(2);
+    });
+
+    it("DarkBlue setSize is 2", () => {
+        expect(GameConfig.setSize.DarkBlue).toBe(2);
+    });
+
+    it("Railroad setSize is 4", () => {
+        expect(GameConfig.setSize.Railroad).toBe(4);
+    });
+});
+
+describe("GameConfig.rentTable", () => {
+    it("has entries for all 10 colors", () => {
+        for (const color of allColors) {
+            expect(GameConfig.rentTable[color]).toBeDefined();
+        }
+    });
+
+    it("rentTable[color].length === setSize[color] + 1 for every color", () => {
+        for (const color of allColors) {
+            expect(GameConfig.rentTable[color].length).toBe(
+                GameConfig.setSize[color] + 1
+            );
+        }
+    });
+
+    it("all rent values are >= 0", () => {
+        for (const color of allColors) {
+            for (const rent of GameConfig.rentTable[color]) {
+                expect(rent).toBeGreaterThanOrEqual(0);
+            }
+        }
+    });
+
+    it("rent values are non-decreasing for each color", () => {
+        for (const color of allColors) {
+            const rents = GameConfig.rentTable[color];
+            for (let i = 1; i < rents.length; i++) {
+                expect(rents[i]).toBeGreaterThanOrEqual(rents[i - 1]);
+            }
+        }
+    });
+
+    it("DarkBlue rents are [0, 3, 8]", () => {
+        expect(GameConfig.rentTable.DarkBlue).toEqual([0, 3, 8]);
+    });
+
+    it("Brown rents are [0, 1, 2]", () => {
+        expect(GameConfig.rentTable.Brown).toEqual([0, 1, 2]);
+    });
+});

--- a/src/web/utilities/Logger.test.ts
+++ b/src/web/utilities/Logger.test.ts
@@ -1,0 +1,51 @@
+import { Logger } from "./Logger";
+import { Debug, DebugFlags } from "./Debug";
+
+beforeEach(() => {
+    Debug.setFlags(DebugFlags.None);
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("Logger", () => {
+    it("log() calls console.log", () => {
+        const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+        Logger.log("hello");
+        expect(spy).toHaveBeenCalledWith("hello");
+    });
+
+    it("error() calls console.error", () => {
+        const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+        Logger.error("bad");
+        expect(spy).toHaveBeenCalledWith("bad");
+    });
+
+    it("warn() calls console.warn", () => {
+        const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+        Logger.warn("careful");
+        expect(spy).toHaveBeenCalledWith("careful");
+    });
+
+    it("debug() logs when VerboseLogging is set", () => {
+        const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+        Debug.setFlags(DebugFlags.VerboseLogging);
+        Logger.debug("verbose message");
+        // setFlags itself logs once, then debug logs
+        expect(spy).toHaveBeenCalledWith("[DEBUG]", "verbose message");
+    });
+
+    it("debug() does NOT log when VerboseLogging is not set", () => {
+        const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+        Logger.debug("should not appear");
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("debug() prepends [DEBUG] to output", () => {
+        const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+        Debug.setFlags(DebugFlags.VerboseLogging);
+        Logger.debug("test", 123);
+        expect(spy).toHaveBeenCalledWith("[DEBUG]", "test", 123);
+    });
+});

--- a/src/web/utilities/PropertyColors.test.ts
+++ b/src/web/utilities/PropertyColors.test.ts
@@ -1,0 +1,64 @@
+import { PropertyColorMap, PropertyColorOrder } from "./PropertyColors";
+
+describe("PropertyColorMap", () => {
+    const allColors = [
+        "Brown", "LightBlue", "Pink", "Orange", "Red",
+        "Yellow", "Green", "DarkBlue", "Railroad", "Utility",
+    ] as const;
+
+    it("contains all 10 colors", () => {
+        for (const color of allColors) {
+            expect(PropertyColorMap[color]).toBeDefined();
+        }
+    });
+
+    it("every entry has name, short, hex, textColor", () => {
+        for (const color of allColors) {
+            const entry = PropertyColorMap[color];
+            expect(entry).toHaveProperty("name");
+            expect(entry).toHaveProperty("short");
+            expect(entry).toHaveProperty("hex");
+            expect(entry).toHaveProperty("textColor");
+        }
+    });
+
+    it("hex values start with #", () => {
+        for (const color of allColors) {
+            expect(PropertyColorMap[color].hex).toMatch(/^#/);
+        }
+    });
+
+    it("textColor is either #fff or #000", () => {
+        for (const color of allColors) {
+            expect(["#fff", "#000"]).toContain(PropertyColorMap[color].textColor);
+        }
+    });
+
+    it("Yellow and Utility have textColor #000, all others #fff", () => {
+        expect(PropertyColorMap.Yellow.textColor).toBe("#000");
+        expect(PropertyColorMap.Utility.textColor).toBe("#000");
+        const darkTextColors: typeof allColors[number][] = ["Yellow", "Utility"];
+        for (const color of allColors) {
+            if (!darkTextColors.includes(color)) {
+                expect(PropertyColorMap[color].textColor).toBe("#fff");
+            }
+        }
+    });
+});
+
+describe("PropertyColorOrder", () => {
+    it("has exactly 10 entries", () => {
+        expect(PropertyColorOrder).toHaveLength(10);
+    });
+
+    it("has no duplicates", () => {
+        const unique = new Set(PropertyColorOrder);
+        expect(unique.size).toBe(PropertyColorOrder.length);
+    });
+
+    it("every color exists in PropertyColorMap", () => {
+        for (const color of PropertyColorOrder) {
+            expect(PropertyColorMap[color]).toBeDefined();
+        }
+    });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
         globals: true,
         setupFiles: ['./src/web/test-setup.ts'],
         passWithNoTests: true,
+        css: false,
     },
     // Dev server with HMR — proxies SignalR to the .NET backend
     server: {


### PR DESCRIPTION
## Changes

### Frontend Tests (53 tests across 6 files)
- **Debug.test.ts** — flags, setFlags, isFlagSet, initFromUrl
- **Logger.test.ts** — log/error/warn/debug with VerboseLogging
- **PropertyColors.test.ts** — map entries, order, hex/textColor validation
- **GameConfig.test.ts** — setSize, rentTable structure & known values
- **Card.test.tsx** — all card types, CSS state classes
- **PlayerSummaryCard.test.tsx** — name, bank, pills, clicks, aria, typing dots

### Documentation
- Updated tech stack in README to include React Testing Library
- Added **Contributing** section with PR-only workflow rules
- Updated DEVELOPMENT.md testing section with coverage details
- Added **Workflow** section (no direct push to main, no --admin bypass)