### PR TITLE
Add UI component tests for 6 untested React components

### DIFF
--- a/src/web/pages/gamePage/components/ActionModal.test.tsx
+++ b/src/web/pages/gamePage/components/ActionModal.test.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ActionModal } from "./ActionModal";
+import { PendingAction, PlayerState, Card } from "../../../Types";
+
+function makeMoneyCard(id: number, value: number): Card {
+    return { id, cardType: "Money", moneyValue: value, name: `${value}M`, isMulticolorWild: false, isWildRent: false };
+}
+
+function makePropertyCard(id: number, name: string, color: string, value = 2): Card {
+    return { id, cardType: "Property", moneyValue: value, name, color: color as any, isMulticolorWild: false, isWildRent: false };
+}
+
+function makePlayer(overrides: Partial<PlayerState> = {}): PlayerState {
+    return {
+        playerId: "me", connectionId: "me-conn", name: "Me", handCount: 3,
+        isConnected: true, bank: [], propertySets: [], unboundWilds: [],
+        completedSetCount: 0, uniqueCompletedSetCount: 0, ...overrides,
+    };
+}
+
+function makePayRentAction(amount = 5): PendingAction {
+    return {
+        type: "PayRent", sourcePlayerId: "other", sourcePlayerName: "Bob",
+        targetPlayerIds: ["me"], amount,
+    };
+}
+
+describe("ActionModal", () => {
+    it("renders payment UI for PayRent action", () => {
+        const myState = makePlayer({ bank: [makeMoneyCard(1, 5)] });
+        render(<ActionModal pendingAction={makePayRentAction()} myState={myState} onRespond={vi.fn()} />);
+        expect(screen.getByText(/Bob charges you rent/)).toBeTruthy();
+    });
+
+    it("shows payment total and selection count", () => {
+        const myState = makePlayer({ bank: [makeMoneyCard(1, 3), makeMoneyCard(2, 2)] });
+        const { container } = render(<ActionModal pendingAction={makePayRentAction(5)} myState={myState} onRespond={vi.fn()} />);
+
+        // Bank is sorted by value, so 2M is first, then 3M
+        const cards = container.querySelectorAll(".md-card");
+        fireEvent.click(cards[0]); // selects 2M card
+        const desc = container.querySelector(".modalDescription");
+        expect(desc?.textContent).toContain("◆2");
+        expect(desc?.textContent).toContain("◆5");
+    });
+
+    it("Pay button disabled when not enough selected", () => {
+        const myState = makePlayer({ bank: [makeMoneyCard(1, 3), makeMoneyCard(2, 4)] });
+        const { container } = render(<ActionModal pendingAction={makePayRentAction(5)} myState={myState} onRespond={vi.fn()} />);
+
+        const payBtn = screen.getByRole("button", { name: /Pay/ });
+        expect(payBtn).toBeDisabled();
+
+        // Select one card (3M — not enough)
+        const cards = container.querySelectorAll(".md-card");
+        fireEvent.click(cards[0]);
+        expect(payBtn).toBeDisabled();
+    });
+
+    it("Pay button enabled when enough selected", () => {
+        const myState = makePlayer({ bank: [makeMoneyCard(1, 3), makeMoneyCard(2, 4)] });
+        const { container } = render(<ActionModal pendingAction={makePayRentAction(5)} myState={myState} onRespond={vi.fn()} />);
+
+        const cards = container.querySelectorAll(".md-card");
+        fireEvent.click(cards[0]); // 3M
+        fireEvent.click(cards[1]); // 4M — total 7 >= 5
+        const payBtn = screen.getByRole("button", { name: /Pay ◆7/ });
+        expect(payBtn).not.toBeDisabled();
+    });
+
+    it("Pay button calls onRespond with selected card IDs", () => {
+        const onRespond = vi.fn();
+        const myState = makePlayer({ bank: [makeMoneyCard(1, 5)] });
+        const { container } = render(<ActionModal pendingAction={makePayRentAction(5)} myState={myState} onRespond={onRespond} />);
+
+        fireEvent.click(container.querySelectorAll(".md-card")[0]);
+        fireEvent.click(screen.getByRole("button", { name: /Pay/ }));
+        expect(onRespond).toHaveBeenCalledWith({ playJustSayNo: false, paymentCardIds: [1] });
+    });
+
+    it("shows Just Say No button when player has JSN card", () => {
+        const jsnCard: Card = { id: 99, cardType: "Action", moneyValue: 4, name: "Just Say No", actionKind: "JustSayNo", isMulticolorWild: false, isWildRent: false };
+        const myState = makePlayer({ hand: [jsnCard], bank: [makeMoneyCard(1, 5)] });
+        render(<ActionModal pendingAction={makePayRentAction(5)} myState={myState} onRespond={vi.fn()} />);
+        expect(screen.getByText("Just Say No!")).toBeTruthy();
+    });
+
+    it("JSN button calls onRespond with playJustSayNo=true", () => {
+        const onRespond = vi.fn();
+        const jsnCard: Card = { id: 99, cardType: "Action", moneyValue: 4, name: "Just Say No", actionKind: "JustSayNo", isMulticolorWild: false, isWildRent: false };
+        const myState = makePlayer({ hand: [jsnCard], bank: [makeMoneyCard(1, 5)] });
+        render(<ActionModal pendingAction={makePayRentAction(5)} myState={myState} onRespond={onRespond} />);
+        fireEvent.click(screen.getByText("Just Say No!"));
+        expect(onRespond).toHaveBeenCalledWith({ playJustSayNo: true });
+    });
+
+    it("displays error message when paymentError prop set", () => {
+        const myState = makePlayer({ bank: [makeMoneyCard(1, 5)] });
+        render(<ActionModal pendingAction={makePayRentAction(5)} myState={myState} paymentError="Not enough!" onRespond={vi.fn()} />);
+        expect(screen.getByText("Not enough!")).toBeTruthy();
+    });
+
+    it("insolvent state: shows give everything button", () => {
+        const myState = makePlayer({ bank: [makeMoneyCard(1, 2)] });
+        render(<ActionModal pendingAction={makePayRentAction(10)} myState={myState} onRespond={vi.fn()} />);
+        expect(screen.getByText(/Give Everything/)).toBeTruthy();
+    });
+
+    it("renders steal UI for RespondToSlyDeal", () => {
+        const action: PendingAction = {
+            type: "RespondToSlyDeal", sourcePlayerId: "other", sourcePlayerName: "Bob",
+            targetPlayerIds: ["me"], amount: 0, targetCardName: "Boardwalk",
+        };
+        const myState = makePlayer();
+        render(<ActionModal pendingAction={action} myState={myState} onRespond={vi.fn()} />);
+        expect(screen.getByText(/Bob plays Sly Deal/)).toBeTruthy();
+        expect(screen.getByText("Boardwalk")).toBeTruthy();
+    });
+
+    it("renders swap UI for RespondToForceDeal", () => {
+        const action: PendingAction = {
+            type: "RespondToForceDeal", sourcePlayerId: "other", sourcePlayerName: "Bob",
+            targetPlayerIds: ["me"], amount: 0, targetCardName: "Park Place", targetCardId: 20,
+            offeredCardName: "Baltic", offeredCardId: 21,
+        };
+        const targetCard = makePropertyCard(20, "Park Place", "DarkBlue");
+        const myState = makePlayer({
+            propertySets: [{
+                setId: 1, color: "DarkBlue", cards: [targetCard], isComplete: false,
+                hasHouse: false, hasHotel: false, rent: 3, requiredSize: 2,
+            }],
+        });
+        render(<ActionModal pendingAction={action} myState={myState} onRespond={vi.fn()} />);
+        expect(screen.getByText(/Bob plays Forced Deal/)).toBeTruthy();
+    });
+
+    it("nothing to pay shows 'I have nothing' button", () => {
+        const myState = makePlayer();
+        render(<ActionModal pendingAction={makePayRentAction(5)} myState={myState} onRespond={vi.fn()} />);
+        expect(screen.getByText("I have nothing")).toBeTruthy();
+    });
+
+    it("PayDebtCollector shows correct title", () => {
+        const action: PendingAction = {
+            type: "PayDebtCollector", sourcePlayerId: "other", sourcePlayerName: "Carol",
+            targetPlayerIds: ["me"], amount: 5,
+        };
+        const myState = makePlayer({ bank: [makeMoneyCard(1, 5)] });
+        render(<ActionModal pendingAction={action} myState={myState} onRespond={vi.fn()} />);
+        expect(screen.getByText(/Carol plays Debt Collector/)).toBeTruthy();
+    });
+});

--- a/src/web/pages/gamePage/components/DiscardModal.test.tsx
+++ b/src/web/pages/gamePage/components/DiscardModal.test.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DiscardModal } from "./DiscardModal";
+import { Card } from "../../../Types";
+
+function makeCard(id: number, name = `Card ${id}`): Card {
+    return { id, cardType: "Money", moneyValue: 1, name, isMulticolorWild: false, isWildRent: false };
+}
+
+const hand = [makeCard(1), makeCard(2), makeCard(3), makeCard(4), makeCard(5), makeCard(6), makeCard(7), makeCard(8), makeCard(9)];
+
+describe("DiscardModal", () => {
+    it("renders correct discard count message", () => {
+        render(<DiscardModal hand={hand} maxHandSize={7} onDiscard={vi.fn()} />);
+        expect(screen.getByText(/You have 9 cards/)).toBeTruthy();
+        expect(screen.getByText(/Select 2 to discard/)).toBeTruthy();
+    });
+
+    it("confirm button shows correct excess count", () => {
+        render(<DiscardModal hand={hand} maxHandSize={7} onDiscard={vi.fn()} />);
+        expect(screen.getByRole("button", { name: /Discard 2 cards/ })).toBeTruthy();
+    });
+
+    it("confirm button is disabled until enough cards selected", () => {
+        const { container } = render(<DiscardModal hand={hand} maxHandSize={7} onDiscard={vi.fn()} />);
+        const btn = screen.getByRole("button", { name: /Discard 2 cards/ });
+        expect(btn).toBeDisabled();
+
+        // Select one card
+        const cards = container.querySelectorAll(".md-card");
+        fireEvent.click(cards[0]);
+        expect(btn).toBeDisabled();
+
+        // Select second card
+        fireEvent.click(cards[1]);
+        expect(btn).not.toBeDisabled();
+    });
+
+    it("card selection toggles (click to select/deselect)", () => {
+        const { container } = render(<DiscardModal hand={hand} maxHandSize={7} onDiscard={vi.fn()} />);
+        const cards = container.querySelectorAll(".md-card");
+
+        fireEvent.click(cards[0]);
+        expect(cards[0].classList.contains("md-card--selected")).toBe(true);
+
+        fireEvent.click(cards[0]);
+        expect(cards[0].classList.contains("md-card--selected")).toBe(false);
+    });
+
+    it("cannot select more cards than excess", () => {
+        const { container } = render(<DiscardModal hand={hand} maxHandSize={7} onDiscard={vi.fn()} />);
+        const cards = container.querySelectorAll(".md-card");
+        // Excess is 2 — select 2 then try a 3rd
+        fireEvent.click(cards[0]);
+        fireEvent.click(cards[1]);
+        fireEvent.click(cards[2]);
+        expect(cards[2].classList.contains("md-card--selected")).toBe(false);
+    });
+
+    it("confirm button calls onDiscard with selected card IDs", () => {
+        const onDiscard = vi.fn();
+        const { container } = render(<DiscardModal hand={hand} maxHandSize={7} onDiscard={onDiscard} />);
+        const cards = container.querySelectorAll(".md-card");
+
+        fireEvent.click(cards[0]); // id=1
+        fireEvent.click(cards[2]); // id=3
+        fireEvent.click(screen.getByRole("button", { name: /Discard 2 cards/ }));
+
+        expect(onDiscard).toHaveBeenCalledWith([1, 3]);
+    });
+
+    it("Go Back button calls onCancel", () => {
+        const onCancel = vi.fn();
+        render(<DiscardModal hand={hand} maxHandSize={7} onDiscard={vi.fn()} onCancel={onCancel} />);
+        fireEvent.click(screen.getByText(/Go Back/));
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("Go Back button is not rendered when onCancel is not provided", () => {
+        render(<DiscardModal hand={hand} maxHandSize={7} onDiscard={vi.fn()} />);
+        expect(screen.queryByText(/Go Back/)).toBeNull();
+    });
+
+    it("uses singular 'card' when excess is 1", () => {
+        const smallHand = hand.slice(0, 8);
+        render(<DiscardModal hand={smallHand} maxHandSize={7} onDiscard={vi.fn()} />);
+        expect(screen.getByRole("button", { name: /Discard 1 card$/ })).toBeTruthy();
+    });
+
+    it("dims unselected cards once enough are selected", () => {
+        const { container } = render(<DiscardModal hand={hand} maxHandSize={7} onDiscard={vi.fn()} />);
+        const cards = container.querySelectorAll(".md-card");
+        fireEvent.click(cards[0]);
+        fireEvent.click(cards[1]);
+        // Card at index 2 should be dimmed
+        expect(cards[2].classList.contains("md-card--dimmed")).toBe(true);
+        // Selected cards should not be dimmed
+        expect(cards[0].classList.contains("md-card--dimmed")).toBe(false);
+    });
+});

--- a/src/web/pages/gamePage/components/FyiToast.test.tsx
+++ b/src/web/pages/gamePage/components/FyiToast.test.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { FyiToast } from "./FyiToast";
+import { GameAction } from "../../../Types";
+
+function makeToast(id: number, text = `Action ${id}`, playerName = "Alice"): GameAction {
+    return { id, playerName, text };
+}
+
+describe("FyiToast", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("renders nothing when no toasts", () => {
+        const { container } = render(<FyiToast toasts={[]} />);
+        expect(container.querySelector(".fyiToast-container")).toBeNull();
+    });
+
+    it("displays toast message text", () => {
+        render(<FyiToast toasts={[makeToast(1, "played a card")]} />);
+        expect(screen.getByText(/played a card/)).toBeTruthy();
+    });
+
+    it("displays player name", () => {
+        render(<FyiToast toasts={[makeToast(1, "drew cards", "Bob")]} />);
+        expect(screen.getByText("Bob")).toBeTruthy();
+    });
+
+    it("auto-dismisses after timeout and sets leaving class", () => {
+        const { container } = render(<FyiToast toasts={[makeToast(1)]} />);
+        expect(container.querySelector(".fyiToast")).toBeTruthy();
+
+        // Advance past the 3000ms auto-dismiss timer
+        act(() => { vi.advanceTimersByTime(3000); });
+        // Should now have leaving class
+        expect(container.querySelector(".fyiToast--leaving")).toBeTruthy();
+    });
+
+    it("close button dismisses current toast", () => {
+        const { container } = render(<FyiToast toasts={[makeToast(1)]} />);
+        fireEvent.click(screen.getByText("✕"));
+        expect(container.querySelector(".fyiToast-container")).toBeNull();
+    });
+
+    it("duplicate prevention: same toast ID not shown twice", () => {
+        const toast = makeToast(1, "hello");
+        const { rerender, container } = render(<FyiToast toasts={[toast]} />);
+        expect(screen.getByText(/hello/)).toBeTruthy();
+
+        // Dismiss current
+        fireEvent.click(screen.getByText("✕"));
+        expect(container.querySelector(".fyiToast-container")).toBeNull();
+
+        // Re-render with same toast — should not re-appear
+        rerender(<FyiToast toasts={[toast]} />);
+        expect(container.querySelector(".fyiToast-container")).toBeNull();
+    });
+
+    it("queue: shows first toast, then next after dismissal", () => {
+        const toasts = [makeToast(1, "first"), makeToast(2, "second")];
+        const { container } = render(<FyiToast toasts={toasts} />);
+        expect(screen.getByText(/first/)).toBeTruthy();
+
+        // Dismiss first
+        fireEvent.click(screen.getByText("✕"));
+        // Second should now show
+        expect(screen.getByText(/second/)).toBeTruthy();
+    });
+
+    it("replaces player name with 'you' when myName matches", () => {
+        const toast = makeToast(1, "Alice played a card on Alice");
+        render(<FyiToast toasts={[toast]} myName="Alice" />);
+        expect(screen.getByText(/you played a card on/)).toBeTruthy();
+    });
+
+    it("calls onBusyChange(true) when toast appears", () => {
+        const onBusyChange = vi.fn();
+        render(<FyiToast toasts={[makeToast(1)]} onBusyChange={onBusyChange} />);
+        expect(onBusyChange).toHaveBeenCalledWith(true);
+    });
+
+    it("calls onBusyChange(false) after toast dismissed and delay", () => {
+        const onBusyChange = vi.fn();
+        const { container } = render(<FyiToast toasts={[makeToast(1)]} onBusyChange={onBusyChange} />);
+
+        fireEvent.click(screen.getByText("✕"));
+        // Not called immediately due to debounce
+        expect(onBusyChange).not.toHaveBeenCalledWith(false);
+
+        act(() => { vi.advanceTimersByTime(1500); });
+        expect(onBusyChange).toHaveBeenCalledWith(false);
+    });
+
+    it("shows card when cardPlayed is present", () => {
+        const toast: GameAction = {
+            id: 1, playerName: "Alice", text: "played Pass Go",
+            cardPlayed: { id: 10, cardType: "Action", moneyValue: 1, name: "Pass Go", actionKind: "PassGo", isMulticolorWild: false, isWildRent: false },
+        };
+        const { container } = render(<FyiToast toasts={[toast]} />);
+        expect(container.querySelector(".fyiToast-cardGroup")).toBeTruthy();
+    });
+});

--- a/src/web/pages/gamePage/components/Hand.test.tsx
+++ b/src/web/pages/gamePage/components/Hand.test.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Hand } from "./Hand";
+import { Card, GameState, PlayerState } from "../../../Types";
+
+// Mock ResizeObserver for jsdom
+globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+} as any;
+
+function makeCard(id: number, name = `Card ${id}`): Card {
+    return { id, cardType: "Money", moneyValue: 1, name, isMulticolorWild: false, isWildRent: false };
+}
+
+function makePlayer(overrides: Partial<PlayerState> = {}): PlayerState {
+    return {
+        playerId: "me", connectionId: "me-conn", name: "Me", handCount: 3,
+        isConnected: true, bank: [], propertySets: [], unboundWilds: [],
+        completedSetCount: 0, uniqueCompletedSetCount: 0, ...overrides,
+    };
+}
+
+function makeGameState(myState: PlayerState): GameState {
+    return {
+        phase: "Play", gameCode: "ABC", players: [myState],
+        currentPlayerIndex: 0, playsUsed: 0, drawPileCount: 40,
+        discardPileCount: 0, recentActions: [],
+    };
+}
+
+function renderHand(overrides: any = {}) {
+    const cards = overrides.cards ?? [makeCard(1), makeCard(2), makeCard(3)];
+    const myState = makePlayer({ hand: cards });
+    const gameState = makeGameState(myState);
+    const props = {
+        cards,
+        canPlay: overrides.canPlay ?? true,
+        phase: overrides.phase ?? "Play",
+        gameState,
+        myConnectionId: "me-conn",
+        playsRemaining: overrides.playsRemaining ?? 3,
+        isMyTurn: overrides.isMyTurn ?? true,
+        onEndTurn: overrides.onEndTurn ?? vi.fn(),
+        onPlayCard: overrides.onPlayCard ?? vi.fn(),
+        onDiscardCard: overrides.onDiscardCard ?? vi.fn(),
+        ...overrides,
+    };
+    return render(<Hand {...props} />);
+}
+
+describe("Hand", () => {
+    it("renders correct number of cards", () => {
+        const { container } = renderHand();
+        const cards = container.querySelectorAll(".md-card");
+        expect(cards.length).toBe(3);
+    });
+
+    it("shows hand count in label", () => {
+        renderHand();
+        expect(screen.getByText(/Your Hand \(3\)/)).toBeTruthy();
+    });
+
+    it("shows 'No cards in hand' when empty", () => {
+        renderHand({ cards: [] });
+        expect(screen.getByText("No cards in hand")).toBeTruthy();
+    });
+
+    it("clicking a card in Play phase opens PlayCardModal", () => {
+        const { container } = renderHand({ phase: "Play" });
+        const cards = container.querySelectorAll(".md-card");
+        fireEvent.click(cards[0]);
+        // PlayCardModal should appear — check for modal overlay
+        expect(container.querySelector(".playCardModal")).toBeTruthy();
+    });
+
+    it("clicking a card in Discard phase calls onDiscardCard directly", () => {
+        const onDiscardCard = vi.fn();
+        const { container } = renderHand({ phase: "Discard", onDiscardCard });
+        const cards = container.querySelectorAll(".md-card");
+        fireEvent.click(cards[0]);
+        expect(onDiscardCard).toHaveBeenCalledWith(1);
+    });
+
+    it("shows 'No Plays Remaining' popup when playsRemaining=0 and isMyTurn", () => {
+        renderHand({ playsRemaining: 0, isMyTurn: true, phase: "Play" });
+        expect(screen.getByText("No Plays Remaining")).toBeTruthy();
+    });
+
+    it("no plays popup not shown when not my turn", () => {
+        renderHand({ playsRemaining: 0, isMyTurn: false, phase: "Play" });
+        expect(screen.queryByText("No Plays Remaining")).toBeNull();
+    });
+
+    it("play counter dots rendered correctly", () => {
+        const { container } = renderHand({ playsRemaining: 1, isMyTurn: true });
+        const filledDots = container.querySelectorAll(".playDot--filled");
+        expect(filledDots.length).toBe(2); // 3 - 1 = 2 plays used
+    });
+
+    it("End Turn button visible during play phase", () => {
+        renderHand({ isMyTurn: true, phase: "Play" });
+        expect(screen.getByText("End Turn")).toBeTruthy();
+    });
+
+    it("End Turn button calls onEndTurn", () => {
+        const onEndTurn = vi.fn();
+        renderHand({ isMyTurn: true, phase: "Play", onEndTurn });
+        fireEvent.click(screen.getByText("End Turn"));
+        expect(onEndTurn).toHaveBeenCalledTimes(1);
+    });
+
+    it("Re-Arrange Cards button dismisses no-plays popup", () => {
+        renderHand({ playsRemaining: 0, isMyTurn: true, phase: "Play" });
+        fireEvent.click(screen.getByText("Re-Arrange Cards"));
+        expect(screen.queryByText("No Plays Remaining")).toBeNull();
+    });
+});

--- a/src/web/pages/gamePage/components/PlayCardModal.test.tsx
+++ b/src/web/pages/gamePage/components/PlayCardModal.test.tsx
@@ -1,0 +1,191 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PlayCardModal } from "./PlayCardModal";
+import { Card, GameState, PlayerState, PropertySetState } from "../../../Types";
+
+function makeMoneyCard(id = 1, value = 5): Card {
+    return { id, cardType: "Money", moneyValue: value, name: `${value}M`, isMulticolorWild: false, isWildRent: false };
+}
+
+function makePropertyCard(id = 2, name = "Baltic Avenue", color = "Brown" as any, value = 1): Card {
+    return { id, cardType: "Property", moneyValue: value, name, color, isMulticolorWild: false, isWildRent: false };
+}
+
+function makeActionCard(id = 3, actionKind = "PassGo" as any, moneyValue = 1, name = "Pass Go"): Card {
+    return { id, cardType: "Action", moneyValue, name, actionKind, isMulticolorWild: false, isWildRent: false };
+}
+
+function makeRentCard(id = 4, colors = ["Brown", "LightBlue"] as any[], isWildRent = false): Card {
+    return { id, cardType: "Rent", moneyValue: 1, name: "Rent", rentColors: colors, isMulticolorWild: false, isWildRent };
+}
+
+function makeWildcard(id = 5, color = "Brown" as any, altColor = "LightBlue" as any): Card {
+    return { id, cardType: "PropertyWildcard", moneyValue: 0, name: "Wild", color, altColor, isMulticolorWild: false, isWildRent: false };
+}
+
+function makeSet(overrides: Partial<PropertySetState> = {}): PropertySetState {
+    return {
+        setId: 1, color: "Brown", cards: [makePropertyCard()], isComplete: false,
+        hasHouse: false, hasHotel: false, rent: 1, requiredSize: 2, ...overrides,
+    };
+}
+
+function makePlayer(overrides: Partial<PlayerState> = {}): PlayerState {
+    return {
+        playerId: "me", connectionId: "me-conn", name: "Me", handCount: 3,
+        isConnected: true, bank: [], propertySets: [], unboundWilds: [],
+        completedSetCount: 0, uniqueCompletedSetCount: 0, ...overrides,
+    };
+}
+
+function makeGameState(players: PlayerState[], playsUsed = 0): GameState {
+    return {
+        phase: "Play", gameCode: "ABC", players, currentPlayerIndex: 0,
+        playsUsed, drawPileCount: 40, discardPileCount: 0, recentActions: [],
+    };
+}
+
+const defaultProps = (card: Card, overrides: any = {}) => {
+    const myState = overrides.myState ?? makePlayer();
+    const others = overrides.otherPlayers ?? [makePlayer({ playerId: "other", connectionId: "other-conn", name: "Bob" })];
+    const gameState = makeGameState([myState, ...others], overrides.playsUsed ?? 0);
+    return {
+        card,
+        gameState,
+        myState,
+        canPlay: overrides.canPlay ?? true,
+        phase: overrides.phase ?? "Play",
+        onPlay: overrides.onPlay ?? vi.fn(),
+        onCancel: overrides.onCancel ?? vi.fn(),
+    };
+};
+
+describe("PlayCardModal", () => {
+    it("money card: shows Bank button and calls onPlay with playAsMoney", () => {
+        const onPlay = vi.fn();
+        render(<PlayCardModal {...defaultProps(makeMoneyCard(), { onPlay })} />);
+        const bankBtn = screen.getByText(/Bank/);
+        fireEvent.click(bankBtn);
+        expect(onPlay).toHaveBeenCalledWith(1, { playAsMoney: true });
+    });
+
+    it("money card: Cancel button calls onCancel", () => {
+        const onCancel = vi.fn();
+        render(<PlayCardModal {...defaultProps(makeMoneyCard(), { onCancel })} />);
+        fireEvent.click(screen.getByText("Cancel"));
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("money card: shows Close instead of Cancel when canPlay is false", () => {
+        render(<PlayCardModal {...defaultProps(makeMoneyCard(), { canPlay: false })} />);
+        expect(screen.getByText("Close")).toBeTruthy();
+        expect(screen.queryByText("Cancel")).toBeNull();
+    });
+
+    it("property card: shows Place button and calls onPlay", () => {
+        const onPlay = vi.fn();
+        const card = makePropertyCard(2, "Baltic Avenue", "Brown");
+        render(<PlayCardModal {...defaultProps(card, { onPlay })} />);
+        fireEvent.click(screen.getByText(/Place/));
+        expect(onPlay).toHaveBeenCalledWith(2, { playAsMoney: false });
+    });
+
+    it("wildcard: shows color picker", () => {
+        const card = makeWildcard(5, "Brown", "LightBlue");
+        render(<PlayCardModal {...defaultProps(card)} />);
+        expect(screen.getByText(/Place as which color/)).toBeTruthy();
+    });
+
+    it("wildcard: clicking color calls onPlay with wildcardColor", () => {
+        const onPlay = vi.fn();
+        const card = makeWildcard(5, "Brown", "LightBlue");
+        const { container } = render(<PlayCardModal {...defaultProps(card, { onPlay })} />);
+        const swatches = container.querySelectorAll(".colorChoice--swatch");
+        fireEvent.click(swatches[0]); // Brown
+        expect(onPlay).toHaveBeenCalledWith(5, { playAsMoney: false, wildcardColor: "Brown" });
+    });
+
+    it("action card: shows Use Action and Bank buttons", () => {
+        const card = makeActionCard(3, "PassGo");
+        const myState = makePlayer();
+        const others = [makePlayer({ playerId: "o", connectionId: "o-conn", name: "Bob" })];
+        render(<PlayCardModal {...defaultProps(card, { myState, otherPlayers: others })} />);
+        expect(screen.getByText(/Use Action/)).toBeTruthy();
+        expect(screen.getByText(/Bank/)).toBeTruthy();
+    });
+
+    it("action PassGo: Use Action calls onPlay directly", () => {
+        const onPlay = vi.fn();
+        const card = makeActionCard(3, "PassGo");
+        render(<PlayCardModal {...defaultProps(card, { onPlay })} />);
+        fireEvent.click(screen.getByText(/Use Action/));
+        expect(onPlay).toHaveBeenCalledWith(3, { playAsMoney: false });
+    });
+
+    it("canUseAction: SlyDeal disabled when no stealable properties", () => {
+        const card = makeActionCard(10, "SlyDeal", 3, "Sly Deal");
+        const otherPlayer = makePlayer({ playerId: "o", connectionId: "o-conn", name: "Bob", propertySets: [] });
+        render(<PlayCardModal {...defaultProps(card, { otherPlayers: [otherPlayer] })} />);
+        const actionBtn = screen.getByText(/Use Action/);
+        expect(actionBtn).toBeDisabled();
+    });
+
+    it("canUseAction: SlyDeal enabled when opponent has non-complete set", () => {
+        const card = makeActionCard(10, "SlyDeal", 3, "Sly Deal");
+        const otherPlayer = makePlayer({
+            playerId: "o", connectionId: "o-conn", name: "Bob",
+            propertySets: [makeSet({ setId: 2, isComplete: false })],
+        });
+        render(<PlayCardModal {...defaultProps(card, { otherPlayers: [otherPlayer] })} />);
+        expect(screen.getByText(/Use Action/)).not.toBeDisabled();
+    });
+
+    it("canUseAction: DealBreaker disabled when no complete sets to steal", () => {
+        const card = makeActionCard(11, "DealBreaker", 5, "Deal Breaker");
+        const otherPlayer = makePlayer({
+            playerId: "o", connectionId: "o-conn", name: "Bob",
+            propertySets: [makeSet({ setId: 2, isComplete: false })],
+        });
+        render(<PlayCardModal {...defaultProps(card, { otherPlayers: [otherPlayer] })} />);
+        expect(screen.getByText(/Use Action/)).toBeDisabled();
+    });
+
+    it("canUseAction: DealBreaker enabled when opponent has complete set", () => {
+        const card = makeActionCard(11, "DealBreaker", 5, "Deal Breaker");
+        const otherPlayer = makePlayer({
+            playerId: "o", connectionId: "o-conn", name: "Bob",
+            propertySets: [makeSet({ setId: 2, isComplete: true, cards: [makePropertyCard(20), makePropertyCard(21)] })],
+        });
+        render(<PlayCardModal {...defaultProps(card, { otherPlayers: [otherPlayer] })} />);
+        expect(screen.getByText(/Use Action/)).not.toBeDisabled();
+    });
+
+    it("Escape key calls onCancel", () => {
+        const onCancel = vi.fn();
+        render(<PlayCardModal {...defaultProps(makeMoneyCard(), { onCancel })} />);
+        fireEvent.keyDown(document, { key: "Escape" });
+        expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("rent card: shows Charge Rent button", () => {
+        const card = makeRentCard(4, ["Brown", "LightBlue"]);
+        const myState = makePlayer({ propertySets: [makeSet()] });
+        render(<PlayCardModal {...defaultProps(card, { myState })} />);
+        expect(screen.getByText(/Charge Rent/)).toBeTruthy();
+    });
+
+    it("rent card: Charge Rent goes to pickRentColor step", () => {
+        const card = makeRentCard(4, ["Brown", "LightBlue"]);
+        const myState = makePlayer({ propertySets: [makeSet()] });
+        render(<PlayCardModal {...defaultProps(card, { myState })} />);
+        fireEvent.click(screen.getByText(/Charge Rent/));
+        expect(screen.getByText(/Choose color to charge rent for/)).toBeTruthy();
+    });
+
+    it("read-only view for non-canPlay wildcard/action/rent shows Close button", () => {
+        const card = makeActionCard(3, "PassGo");
+        render(<PlayCardModal {...defaultProps(card, { canPlay: false })} />);
+        expect(screen.getByText("Close")).toBeTruthy();
+        expect(screen.queryByText(/Use Action/)).toBeNull();
+    });
+});

--- a/src/web/pages/gamePage/components/PlayerBoard.test.tsx
+++ b/src/web/pages/gamePage/components/PlayerBoard.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { PlayerBoard } from "./PlayerBoard";
+import { PlayerState, Card, PropertySetState } from "../../../Types";
+
+function makeMoneyCard(id: number, value: number): Card {
+    return { id, cardType: "Money", moneyValue: value, name: `${value}M`, isMulticolorWild: false, isWildRent: false };
+}
+
+function makePropertyCard(id: number, name: string, color: string, value = 2): Card {
+    return { id, cardType: "Property", moneyValue: value, name, color: color as any, isMulticolorWild: false, isWildRent: false };
+}
+
+function makeSet(overrides: Partial<PropertySetState> = {}): PropertySetState {
+    return {
+        setId: 1, color: "Brown", cards: [], isComplete: false,
+        hasHouse: false, hasHotel: false, rent: 1, requiredSize: 2, ...overrides,
+    };
+}
+
+function makePlayer(overrides: Partial<PlayerState> = {}): PlayerState {
+    return {
+        playerId: "p1", connectionId: "c1", name: "Alice", handCount: 3,
+        isConnected: true, bank: [], propertySets: [], unboundWilds: [],
+        completedSetCount: 0, uniqueCompletedSetCount: 0, ...overrides,
+    };
+}
+
+describe("PlayerBoard", () => {
+    it("renders player name", () => {
+        render(<PlayerBoard player={makePlayer()} />);
+        expect(screen.getByText("Alice")).toBeTruthy();
+    });
+
+    it("renders bank total", () => {
+        const player = makePlayer({ bank: [makeMoneyCard(1, 5), makeMoneyCard(2, 3)] });
+        const { container } = render(<PlayerBoard player={player} />);
+        const total = container.querySelector(".playerBoard-bank-total");
+        expect(total?.textContent).toContain("8");
+    });
+
+    it("renders bank pills grouped by denomination", () => {
+        const player = makePlayer({ bank: [makeMoneyCard(1, 5), makeMoneyCard(2, 5), makeMoneyCard(3, 1)] });
+        const { container } = render(<PlayerBoard player={player} />);
+        const pills = container.querySelectorAll(".bank-pill");
+        expect(pills.length).toBe(2); // ◆1 and ◆5
+        expect(pills[0].textContent).toContain("◆1");
+        expect(pills[1].textContent).toContain("◆5 ×2");
+    });
+
+    it("empty bank shows Bank Empty", () => {
+        const player = makePlayer();
+        render(<PlayerBoard player={player} />);
+        expect(screen.getByText("Bank Empty")).toBeTruthy();
+    });
+
+    it("empty properties shows 'No properties'", () => {
+        render(<PlayerBoard player={makePlayer()} />);
+        expect(screen.getByText("No properties")).toBeTruthy();
+    });
+
+    it("renders property sets with color headers", () => {
+        const card = makePropertyCard(10, "Baltic", "Brown");
+        const player = makePlayer({
+            propertySets: [makeSet({ setId: 1, color: "Brown", cards: [card], requiredSize: 2 })],
+        });
+        const { container } = render(<PlayerBoard player={player} />);
+        const label = container.querySelector(".propertySet-label");
+        expect(label?.textContent).toContain("1/2");
+    });
+
+    it("shows completed set indicator (checkmark)", () => {
+        const cards = [makePropertyCard(10, "Baltic", "Brown"), makePropertyCard(11, "Mediterranean", "Brown")];
+        const player = makePlayer({
+            propertySets: [makeSet({ setId: 1, color: "Brown", cards, isComplete: true, requiredSize: 2 })],
+            completedSetCount: 1,
+        });
+        const { container } = render(<PlayerBoard player={player} />);
+        const label = container.querySelector(".propertySet-label");
+        expect(label?.textContent).toContain("✓");
+    });
+
+    it("shows house on set that has one", () => {
+        const cards = [makePropertyCard(10, "Baltic", "Brown"), makePropertyCard(11, "Mediterranean", "Brown")];
+        const player = makePlayer({
+            propertySets: [makeSet({ setId: 1, color: "Brown", cards, isComplete: true, hasHouse: true, requiredSize: 2 })],
+        });
+        const { container } = render(<PlayerBoard player={player} />);
+        expect(container.querySelector('img[alt="House"]')).toBeTruthy();
+    });
+
+    it("shows hotel on set that has one", () => {
+        const cards = [makePropertyCard(10, "Baltic", "Brown"), makePropertyCard(11, "Mediterranean", "Brown")];
+        const player = makePlayer({
+            propertySets: [makeSet({ setId: 1, color: "Brown", cards, isComplete: true, hasHouse: true, hasHotel: true, requiredSize: 2 })],
+        });
+        const { container } = render(<PlayerBoard player={player} />);
+        expect(container.querySelector('img[alt="Hotel"]')).toBeTruthy();
+    });
+
+    it("shows completed set count", () => {
+        const player = makePlayer({ completedSetCount: 2 });
+        render(<PlayerBoard player={player} />);
+        expect(screen.getByText("2/3 sets")).toBeTruthy();
+    });
+
+    it("no drag controls on opponent boards (isMe=false)", () => {
+        const card = makePropertyCard(10, "Baltic", "Brown");
+        const player = makePlayer({
+            propertySets: [makeSet({ setId: 1, color: "Brown", cards: [card] })],
+        });
+        const { container } = render(<PlayerBoard player={player} isMe={false} isMyTurn={true} onFlipCard={vi.fn()} />);
+        // No "New Set" drop target on opponent board
+        expect(container.querySelector(".propertySet-new")).toBeNull();
+    });
+
+    it("shows New Set drop target when isMe and isMyTurn with onMoveProperty", () => {
+        const card = makePropertyCard(10, "Baltic", "Brown");
+        const player = makePlayer({
+            propertySets: [makeSet({ setId: 1, color: "Brown", cards: [card] })],
+        });
+        const { container } = render(<PlayerBoard player={player} isMe={true} isMyTurn={true} onMoveProperty={vi.fn()} />);
+        expect(container.querySelector(".propertySet-new")).toBeTruthy();
+    });
+
+    it("shows hand count for opponents, hand length for self", () => {
+        const player = makePlayer({ handCount: 5, hand: [makeMoneyCard(1, 1), makeMoneyCard(2, 2)] });
+        const { container: opponentContainer } = render(<PlayerBoard player={player} isMe={false} />);
+        const opponentCards = opponentContainer.querySelector(".playerBoard-cards");
+        expect(opponentCards?.textContent).toContain("5");
+
+        const { container: myContainer } = render(<PlayerBoard player={player} isMe={true} />);
+        const myCards = myContainer.querySelector(".playerBoard-cards");
+        expect(myCards?.textContent).toContain("2");
+    });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive Vitest component tests for all previously untested React components.

### New Test Files (74 new tests)

| Component | Tests | Coverage |
|---|---|---|
| **DiscardModal** | 10 | Selection toggle, excess limit, confirm/cancel, card dimming |
| **FyiToast** | 11 | Queue logic, auto-dismiss, dedup, myName→'you', busy callback |
| **ActionModal** | 13 | Payment selection/totals, JSN button, steal/swap UI, insolvency |
| **PlayCardModal** | 16 | Money/property/wildcard/rent flows, canUseAction, Escape key |
| **Hand** | 11 | Card rendering, modal open, discard phase, no-plays popup, play dots |
| **PlayerBoard** | 13 | Bank pills, property sets, checkmarks, house/hotel, drag controls |

### Totals
- **127 frontend tests** (53 existing + 74 new), all passing
- **405 total tests** across the project (127 frontend + 278 backend)
- Every game UI component now has test coverage