### PR TITLE
Fix Pink property rent values to match official cards

### DIFF
--- a/src/JeffopolyDeal.Shared/Models/GameConfig.cs
+++ b/src/JeffopolyDeal.Shared/Models/GameConfig.cs
@@ -32,7 +32,7 @@ namespace JeffopolyDeal.Models
         {
             { PropertyColor.Brown,     new[] { 0, 1, 2 } },
             { PropertyColor.LightBlue, new[] { 0, 1, 2, 3 } },
-            { PropertyColor.Pink,      new[] { 0, 2, 4, 6 } },
+            { PropertyColor.Pink,      new[] { 0, 1, 2, 4 } },
             { PropertyColor.Orange,    new[] { 0, 1, 3, 5 } },
             { PropertyColor.Red,       new[] { 0, 2, 3, 6 } },
             { PropertyColor.Yellow,    new[] { 0, 2, 4, 6 } },

--- a/src/web/utilities/GameConfig.ts
+++ b/src/web/utilities/GameConfig.ts
@@ -10,7 +10,7 @@ export const GameConfig = {
     rentTable: {
         Brown:     [0, 1, 2],
         LightBlue: [0, 1, 2, 3],
-        Pink:      [0, 2, 4, 6],
+        Pink:      [0, 1, 2, 4],
         Orange:    [0, 1, 3, 5],
         Red:       [0, 2, 3, 6],
         Yellow:    [0, 2, 4, 6],


### PR DESCRIPTION
Pink rents were `[0, 2, 4, 6]` but should be `[0, 1, 2, 4]` per the actual Monopoly Deal cards.

Updated in both:
- **Backend:** `GameConfig.cs`
- **Frontend:** `GameConfig.ts`

All tests pass.