### PR TITLE
Add 'Add Bot Player' button to game lobby

### DIFF
--- a/src/JeffopolyDeal.Game/Game.cs
+++ b/src/JeffopolyDeal.Game/Game.cs
@@ -245,6 +245,15 @@ namespace JeffopolyDeal
             await BroadcastGameStateAsync();
         }
 
+        private static readonly string[] BotNames = new[]
+        {
+            "Alice", "Bob", "Charlie", "Diana", "Eve",
+            "Frank", "Grace", "Hank", "Iris", "Jake",
+            "Karen", "Leo", "Mona", "Nate", "Olive"
+        };
+
+        private static readonly Random _botRng = new();
+
         /// <summary>
         /// Adds bot players to the lobby for debug purposes.
         /// </summary>
@@ -253,15 +262,42 @@ namespace JeffopolyDeal
             lock (_lock)
             {
                 if (_phase != GamePhase.Lobby) return;
-                var botNames = new[] { "Alice", "Bob", "Charlie", "Diana", "Eve" };
                 for (int i = 0; i < count && _players.Count < 5; i++)
                 {
-                    var name = botNames[i % botNames.Length];
+                    var name = PickUnusedBotName();
                     var botId = $"bot-{Guid.NewGuid():N}";
                     _players.Add(new Player { PlayerId = botId, ConnectionId = botId, Name = name });
                     _connections[botId] = true;
                 }
             }
+        }
+
+        /// <summary>
+        /// Adds a single bot player to the lobby. Returns true if a bot was added.
+        /// </summary>
+        public bool AddBotPlayer()
+        {
+            lock (_lock)
+            {
+                if (_phase != GamePhase.Lobby) return false;
+                if (_players.Count >= 5) return false;
+
+                var name = PickUnusedBotName();
+                var botId = $"bot-{Guid.NewGuid():N}";
+                _players.Add(new Player { PlayerId = botId, ConnectionId = botId, Name = name });
+                _connections[botId] = true;
+                return true;
+            }
+        }
+
+        private string PickUnusedBotName()
+        {
+            var usedNames = _players.Select(p => p.Name).ToHashSet();
+            var available = BotNames.Where(n => !usedNames.Contains(n)).ToArray();
+            if (available.Length > 0)
+                return available[_botRng.Next(available.Length)];
+            // Fallback if all names taken
+            return $"Bot-{_botRng.Next(1000):D3}";
         }
 
         /// <summary>

--- a/src/JeffopolyDeal.Game/GameCache.cs
+++ b/src/JeffopolyDeal.Game/GameCache.cs
@@ -73,6 +73,18 @@ namespace JeffopolyDeal
             return await game.ReconnectPlayerAsync(connectionId, playerName, playerId);
         }
 
+        public async Task AddBotPlayerAsync(string gameCode)
+        {
+            gameCode = gameCode.ToUpperInvariant();
+            if (!_games.TryGetValue(gameCode, out var game))
+                return;
+
+            if (game.AddBotPlayer())
+            {
+                await game.BroadcastGameStateAsync();
+            }
+        }
+
         public async Task StartGameAsync(
             string gameCode,
             bool allowSinglePlayer = false,

--- a/src/JeffopolyDeal.Game/Hubs/GameHub.cs
+++ b/src/JeffopolyDeal.Game/Hubs/GameHub.cs
@@ -71,6 +71,19 @@ namespace JeffopolyDeal.Hubs
             }
         }
 
+        public async Task AddBotPlayer(string gameCode)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(gameCode)) throw new ArgumentNullException(nameof(gameCode));
+                await _gameCache.AddBotPlayerAsync(gameCode);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in AddBotPlayer for {GameCode}", gameCode);
+            }
+        }
+
         public async Task StartGame(
             string gameCode,
             bool allowSinglePlayer = false,

--- a/src/web/pages/gamePage/GamePage.tsx
+++ b/src/web/pages/gamePage/GamePage.tsx
@@ -256,6 +256,14 @@ export function GamePage({ gameCode, playerName, playerId, isRejoin, onGameCodeR
                                 {!p.isConnected && <span className="disconnectedLabel"> (reconnecting...)</span>}
                             </div>
                         ))}
+                        {canStart && state.players.length < 5 && (
+                            <button
+                                className="addBotButton"
+                                onClick={() => client?.addBotPlayer(state.gameCode)}
+                            >
+                                + Add Bot Player
+                            </button>
+                        )}
                     </div>
                     {canStart && (
                         <button

--- a/src/web/pages/gamePage/GameSignalRClient.ts
+++ b/src/web/pages/gamePage/GameSignalRClient.ts
@@ -73,6 +73,10 @@ export class GameSignalRClient {
         return await this.connection.invoke<boolean>("RejoinGame", gameCode, playerName, playerId);
     }
 
+    async addBotPlayer(gameCode: string): Promise<void> {
+        await this.connection.invoke("AddBotPlayer", gameCode);
+    }
+
     async startGame(
         gameCode: string,
         allowSinglePlayer: boolean = false,

--- a/src/web/pages/gamePage/styles/game.css
+++ b/src/web/pages/gamePage/styles/game.css
@@ -135,6 +135,24 @@ html.pwa-standalone .gamePage {
     font-style: italic;
 }
 
+.addBotButton {
+    margin-top: 10px;
+    padding: 6px 14px;
+    font-size: 0.8rem;
+    background: transparent;
+    color: #6fa;
+    border: 1px dashed #6fa;
+    border-radius: 6px;
+    cursor: pointer;
+    width: 100%;
+    transition: background 0.2s, color 0.2s;
+}
+
+.addBotButton:hover {
+    background: rgba(102, 255, 170, 0.15);
+    color: #9fc;
+}
+
 .waitingText {
     color: #888;
     font-style: italic;


### PR DESCRIPTION
Allow the game host to add bot players one at a time from the lobby. Bot names are picked at random from a pool of 15 names, avoiding duplicates with existing players.

### Changes
- **Game.cs**: Add `AddBotPlayer()` method and expanded bot name pool (15 names)
- **GameCache.cs**: Add `AddBotPlayerAsync()` to find game and broadcast state
- **GameHub.cs**: Add `AddBotPlayer` SignalR hub method
- **GameSignalRClient.ts**: Add `addBotPlayer()` client method
- **GamePage.tsx**: Add '+ Add Bot Player' button in lobby player list (host only, when < 5 players)
- **game.css**: Style the add bot button