### PR TITLE
Add Application Insights with OpenTelemetry and game telemetry

### DIFF
--- a/docs/kql-queries.md
+++ b/docs/kql-queries.md
@@ -1,0 +1,170 @@
+# Jeffopoly Deal — KQL Queries for Application Insights
+
+Paste these into **Application Insights → Logs** (or a Workbook) to analyze game telemetry.
+
+---
+
+## Games Overview (last 7 days)
+
+```kql
+traces
+| where timestamp > ago(7d)
+| where message startswith "GameStarted"
+| extend GameId = tostring(customDimensions.GameId),
+         PlayerCount = toint(customDimensions.PlayerCount),
+         BotCount = toint(customDimensions.BotCount)
+| summarize Games = count(),
+            AvgPlayers = avg(PlayerCount),
+            AvgBots = avg(BotCount)
+```
+
+## Games Per Day
+
+```kql
+traces
+| where timestamp > ago(30d)
+| where message startswith "GameStarted"
+| summarize Games = count() by bin(timestamp, 1d)
+| order by timestamp asc
+| render timechart
+```
+
+## Average Game Duration & Turns
+
+```kql
+traces
+| where timestamp > ago(7d)
+| where message startswith "GameEnded"
+| extend Duration = todouble(customDimensions.DurationSeconds),
+         Turns = toint(customDimensions.TurnCount)
+| summarize AvgDuration = avg(Duration),
+            MedianDuration = percentile(Duration, 50),
+            AvgTurns = avg(Turns),
+            MedianTurns = percentile(Turns, 50),
+            Games = count()
+```
+
+## Win Rate: Humans vs Bots
+
+```kql
+traces
+| where timestamp > ago(30d)
+| where message startswith "GameEnded"
+| extend WinnerIsBot = tobool(customDimensions.WinnerIsBot)
+| summarize Wins = count() by WinnerIsBot
+| extend WinnerType = iff(WinnerIsBot, "Bot", "Human")
+| project WinnerType, Wins
+| render piechart
+```
+
+## Most Played Card Types
+
+```kql
+traces
+| where timestamp > ago(7d)
+| where message startswith "CardPlayed"
+| extend CardType = tostring(customDimensions.CardType),
+         PlayedAsMoney = tobool(customDimensions.PlayedAsMoney)
+| summarize Count = count() by CardType, PlayedAsMoney
+| order by Count desc
+```
+
+## Most Used Action Cards
+
+```kql
+traces
+| where timestamp > ago(7d)
+| where message startswith "CardPlayed"
+| where customDimensions.CardType == "Action"
+| extend ActionType = tostring(customDimensions.ActionType),
+         PlayedAsMoney = tobool(customDimensions.PlayedAsMoney)
+| summarize Count = count() by ActionType, PlayedAsMoney
+| order by Count desc
+```
+
+## Just Say No Usage Rate
+
+```kql
+traces
+| where timestamp > ago(30d)
+| where message startswith "ActionResponse"
+| extend ResponseType = tostring(customDimensions.ResponseType),
+         PlayerIsBot = tobool(customDimensions.PlayerIsBot)
+| summarize Count = count() by ResponseType, PlayerIsBot
+| order by Count desc
+```
+
+## Rent Collection by Color
+
+```kql
+traces
+| where timestamp > ago(7d)
+| where message startswith "CardPlayed"
+| where customDimensions.CardType == "Rent"
+| where tobool(customDimensions.PlayedAsMoney) == false
+| extend RentColor = tostring(customDimensions.RentColor),
+         RentAmount = toint(customDimensions.RentAmount)
+| summarize TimesCharged = count(),
+            TotalRent = sum(RentAmount),
+            AvgRent = avg(RentAmount) by RentColor
+| order by TimesCharged desc
+```
+
+## Cards Banked as Money (instead of played)
+
+```kql
+traces
+| where timestamp > ago(7d)
+| where message startswith "CardPlayed"
+| where tobool(customDimensions.PlayedAsMoney) == true
+| extend CardType = tostring(customDimensions.CardType),
+         CardName = tostring(customDimensions.CardName)
+| summarize Count = count() by CardType, CardName
+| order by Count desc
+```
+
+## Bot vs Human Card Play Patterns
+
+```kql
+traces
+| where timestamp > ago(7d)
+| where message startswith "CardPlayed"
+| extend PlayerIsBot = tobool(customDimensions.PlayerIsBot),
+         CardType = tostring(customDimensions.CardType)
+| summarize Count = count() by PlayerType = iff(PlayerIsBot, "Bot", "Human"), CardType
+| order by PlayerType, Count desc
+```
+
+## Game Duration Distribution (histogram)
+
+```kql
+traces
+| where timestamp > ago(30d)
+| where message startswith "GameEnded"
+| extend Duration = todouble(customDimensions.DurationSeconds)
+| summarize Count = count() by DurationBucket = bin(Duration, 60)
+| order by DurationBucket asc
+| render columnchart
+```
+
+## Player Roster for a Specific Game
+
+```kql
+traces
+| where message startswith "GameStarted"
+| extend GameId = tostring(customDimensions.GameId),
+         Players = tostring(customDimensions.Players)
+| where GameId == "<GAME_ID_HERE>"
+| project timestamp, GameId, Players
+```
+
+## Full Event Timeline for a Game
+
+```kql
+traces
+| where customDimensions.GameId == "<GAME_ID_HERE>"
+| project timestamp,
+          Event = extract(@"^(\w+)", 1, message),
+          Details = customDimensions
+| order by timestamp asc
+```

--- a/src/JeffopolyDeal.Game/Game.cs
+++ b/src/JeffopolyDeal.Game/Game.cs
@@ -3,8 +3,11 @@ using JeffopolyDeal.Hubs;
 using JeffopolyDeal.ISMCTS;
 using JeffopolyDeal.Models;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,16 +22,20 @@ namespace JeffopolyDeal
     {
         private readonly object _lock = new();
         private readonly IHubContext<GameHub> _hubContext;
+        private readonly ILogger<Game> _logger;
         private readonly Deck _deck;
 
         public string GameCode { get; }
         public string ThemeName { get; }
+        private readonly string _gameId = Guid.NewGuid().ToString("N")[..12];
+        private readonly Stopwatch _gameStopwatch = new();
 
         private readonly List<Player> _players = new();
         private readonly Dictionary<string, bool> _connections = new();
 
         private int _currentPlayerIndex;
         private int _playsUsed;
+        private int _turnNumber;
         private GamePhase _phase = GamePhase.Lobby;
         private PendingAction? _pendingAction;
         private string? _winnerId;
@@ -39,9 +46,10 @@ namespace JeffopolyDeal
         private int _nextActionId = 1;
         private List<Card> _discardedThisTurn = new();
 
-        public Game(IHubContext<GameHub> hubContext, string gameCode, string? themeName = null)
+        public Game(IHubContext<GameHub> hubContext, ILogger<Game> logger, string gameCode, string? themeName = null)
         {
             _hubContext = hubContext;
+            _logger = logger;
             GameCode = gameCode;
             ThemeName = themeName ?? "jeffopoly";
             _deck = new Deck(ThemeName);
@@ -229,7 +237,20 @@ namespace JeffopolyDeal
 
                 _currentPlayerIndex = startingPlayerIndex ?? Random.Shared.Next(_players.Count);
                 _playsUsed = 0;
+                _turnNumber = 1;
                 _phase = GamePhase.Draw;
+                _gameStopwatch.Restart();
+
+                // Telemetry: GameStarted
+                var botCount = _players.Count(p => SmartBotAI.IsBot(p.ConnectionId));
+                _logger.LogInformation("GameStarted {GameId} {GameCode} {PlayerCount} {BotCount} {Theme} {Players}",
+                    _gameId, GameCode, _players.Count, botCount, ThemeName,
+                    JsonConvert.SerializeObject(_players.Select(p => new
+                    {
+                        p.PlayerId,
+                        p.Name,
+                        IsBot = SmartBotAI.IsBot(p.ConnectionId)
+                    })));
 
                 if (populateBoards)
                 {
@@ -439,16 +460,24 @@ namespace JeffopolyDeal
                     targetPlayerName: request.TargetPlayerId != null
                         ? _players.FirstOrDefault(p => p.ConnectionId == request.TargetPlayerId)?.Name
                         : null);
+
+                // Telemetry: CardPlayed
+                var targetIsBot = request.TargetPlayerId != null && SmartBotAI.IsBot(request.TargetPlayerId);
+                _logger.LogInformation(
+                    "CardPlayed {GameId} {TurnNumber} {PlayerIsBot} {CardType} {CardName} {ActionType} {PlayedAsMoney} {TargetPlayerIsBot} {RentColor} {RentAmount}",
+                    _gameId, _turnNumber, SmartBotAI.IsBot(player.ConnectionId),
+                    card.CardType.ToString(), card.Name, card.ActionKind?.ToString(),
+                    request.PlayAsMoney, targetIsBot,
+                    request.RentColor?.ToString(), _pendingAction?.Amount);
+
                 player.Hand.Remove(card);
                 _playsUsed++;
 
                 // Check win condition
                 if (player.UniqueCompletedSetCount >= GameConfig.SetsToWin)
                 {
-                    _phase = GamePhase.GameOver;
-                    _winnerId = player.PlayerId;
+                    SetGameOver(player.PlayerId);
                 }
-                // If pending action, wait for response
                 else if (_pendingAction != null)
                 {
                     _phase = GamePhase.AwaitingResponse;
@@ -882,6 +911,15 @@ namespace JeffopolyDeal
         {
             if (_pendingAction == null) return;
 
+            // Telemetry: ActionResponse
+            var responderPlayer = _players.FirstOrDefault(p => p.ConnectionId == connectionId);
+            var responseType = response.PlayJustSayNo ? "JustSayNo" : "Pay";
+            _logger.LogInformation(
+                "ActionResponse {GameId} {TurnNumber} {ResponseType} {PlayerIsBot} {AmountPaid}",
+                _gameId, _turnNumber, responseType,
+                SmartBotAI.IsBot(connectionId),
+                response.PaymentCardIds?.Count ?? 0);
+
             // Handle Just Say No
             if (response.PlayJustSayNo)
             {
@@ -1030,8 +1068,7 @@ namespace JeffopolyDeal
                 var currentPlayer = GetCurrentPlayer();
                 if (currentPlayer != null && currentPlayer.UniqueCompletedSetCount >= GameConfig.SetsToWin)
                 {
-                    _phase = GamePhase.GameOver;
-                    _winnerId = currentPlayer.PlayerId;
+                    SetGameOver(currentPlayer.PlayerId);
                 }
                 // If current player is a bot, resume their turn
                 else if (currentPlayer != null && SmartBotAI.IsBot(currentPlayer.ConnectionId))
@@ -1273,6 +1310,19 @@ namespace JeffopolyDeal
                 _recentActions.RemoveAt(0);
         }
 
+        private void SetGameOver(string winnerPlayerId)
+        {
+            _phase = GamePhase.GameOver;
+            _winnerId = winnerPlayerId;
+
+            var winner = _players.FirstOrDefault(p => p.PlayerId == winnerPlayerId);
+            _logger.LogInformation(
+                "GameEnded {GameId} {GameCode} {DurationSeconds} {TurnCount} {PlayerCount} {BotCount} {WinnerIsBot} {WinnerName}",
+                _gameId, GameCode, _gameStopwatch.Elapsed.TotalSeconds, _turnNumber,
+                _players.Count, _players.Count(p => SmartBotAI.IsBot(p.ConnectionId)),
+                winner != null && SmartBotAI.IsBot(winner.ConnectionId), winner?.Name);
+        }
+
         private string DescribeCardPlay(Player player, Card card, PlayCardRequest request)
         {
             if (request.PlayAsMoney)
@@ -1345,6 +1395,7 @@ namespace JeffopolyDeal
         {
             _currentPlayerIndex = (_currentPlayerIndex + 1) % _players.Count;
             _playsUsed = 0;
+            _turnNumber++;
             _pendingAction = null;
             _discardedThisTurn.Clear();
             _phase = GamePhase.Draw;
@@ -1414,8 +1465,7 @@ namespace JeffopolyDeal
             // Check win
             if (bot.UniqueCompletedSetCount >= GameConfig.SetsToWin)
             {
-                _phase = GamePhase.GameOver;
-                _winnerId = bot.PlayerId;
+                SetGameOver(bot.PlayerId);
                 return;
             }
 
@@ -1477,8 +1527,7 @@ namespace JeffopolyDeal
 
             if (bot.UniqueCompletedSetCount >= GameConfig.SetsToWin)
             {
-                _phase = GamePhase.GameOver;
-                _winnerId = bot.PlayerId;
+                SetGameOver(bot.PlayerId);
                 return;
             }
 
@@ -1763,8 +1812,7 @@ namespace JeffopolyDeal
             // Check if this rearrangement completed the win condition (issue #95).
             if (player.UniqueCompletedSetCount >= GameConfig.SetsToWin)
             {
-                _phase = GamePhase.GameOver;
-                _winnerId = player.PlayerId;
+                SetGameOver(player.PlayerId);
             }
         }
 
@@ -1807,8 +1855,7 @@ namespace JeffopolyDeal
                         // Check if the flip completed the win condition (issue #95).
                         if (player.UniqueCompletedSetCount >= GameConfig.SetsToWin)
                         {
-                            _phase = GamePhase.GameOver;
-                            _winnerId = player.PlayerId;
+                            SetGameOver(player.PlayerId);
                         }
                         break;
                     }

--- a/src/JeffopolyDeal.Game/GameCache.cs
+++ b/src/JeffopolyDeal.Game/GameCache.cs
@@ -1,6 +1,7 @@
 using JeffopolyDeal.Hubs;
 using JeffopolyDeal.Models;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
@@ -15,15 +16,17 @@ namespace JeffopolyDeal
     public class GameCache
     {
         private readonly IHubContext<GameHub> _hubContext;
+        private readonly ILoggerFactory _loggerFactory;
         private readonly ConcurrentDictionary<string, string> _connectionToGame = new();
         private readonly ConcurrentDictionary<string, Game> _games = new();
         private readonly ConcurrentDictionary<string, CancellationTokenSource> _cleanupTimers = new();
         private readonly Random _rng = new();
         private static readonly TimeSpan LobbyCleanupDelay = TimeSpan.FromMinutes(2);
 
-        public GameCache(IHubContext<GameHub> hubContext)
+        public GameCache(IHubContext<GameHub> hubContext, ILoggerFactory loggerFactory)
         {
             _hubContext = hubContext;
+            _loggerFactory = loggerFactory;
         }
 
         public string CreateGame(string? fixedCode = null, string? themeName = null)
@@ -31,7 +34,7 @@ namespace JeffopolyDeal
             if (!string.IsNullOrEmpty(fixedCode))
             {
                 var code = fixedCode.ToUpperInvariant();
-                var game = new Game(_hubContext, code, themeName);
+                var game = new Game(_hubContext, _loggerFactory.CreateLogger<Game>(), code, themeName);
                 _games[code] = game;
                 return code;
             }
@@ -42,7 +45,7 @@ namespace JeffopolyDeal
                 gameCode = GenerateGameCode();
             } while (_games.ContainsKey(gameCode));
 
-            var newGame = new Game(_hubContext, gameCode, themeName);
+            var newGame = new Game(_hubContext, _loggerFactory.CreateLogger<Game>(), gameCode, themeName);
             _games[gameCode] = newGame;
             return gameCode;
         }

--- a/src/JeffopolyDeal.Game/JeffopolyDeal.Game.csproj
+++ b/src/JeffopolyDeal.Game/JeffopolyDeal.Game.csproj
@@ -22,4 +22,7 @@
   <ItemGroup>
     <Content Update="Themes\**" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="*" />
+  </ItemGroup>
 </Project>

--- a/src/JeffopolyDeal.Game/Program.cs
+++ b/src/JeffopolyDeal.Game/Program.cs
@@ -1,3 +1,4 @@
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using JeffopolyDeal.Hubs;
 using Microsoft.AspNetCore.Builder;
 using System.Linq;
@@ -8,6 +9,12 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Application Insights via OpenTelemetry (reads APPLICATIONINSIGHTS_CONNECTION_STRING from config)
+if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+{
+    builder.Services.AddOpenTelemetry().UseAzureMonitor();
+}
 
 builder.Services.AddSignalR()
     .AddJsonProtocol(options =>

--- a/src/JeffopolyDeal.Game/appsettings.json
+++ b/src/JeffopolyDeal.Game/appsettings.json
@@ -6,5 +6,6 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "APPLICATIONINSIGHTS_CONNECTION_STRING": ""
 }

--- a/tests/JeffopolyDeal.Game.Tests/GameCacheTests.cs
+++ b/tests/JeffopolyDeal.Game.Tests/GameCacheTests.cs
@@ -1,6 +1,8 @@
 using JeffopolyDeal.Hubs;
 using JeffopolyDeal.Models;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using System.Collections.Concurrent;
 using System.Threading;
@@ -53,7 +55,7 @@ namespace JeffopolyDeal.Tests
         public async Task EndGame_RemovesGameStateFromCache()
         {
             var hubContext = CreateMockHubContext(new ConcurrentDictionary<string, GameState>());
-            var cache = new GameCache(hubContext);
+            var cache = new GameCache(hubContext, NullLoggerFactory.Instance);
 
             const string code = "ABCD";
             cache.CreateGame(code);
@@ -70,7 +72,7 @@ namespace JeffopolyDeal.Tests
         {
             var states = new ConcurrentDictionary<string, GameState>();
             var hubContext = CreateMockHubContext(states);
-            var cache = new GameCache(hubContext);
+            var cache = new GameCache(hubContext, NullLoggerFactory.Instance);
 
             const string code = "WXYZ";
             cache.CreateGame(code);

--- a/tests/JeffopolyDeal.Game.Tests/MoneyAndPropertyTests.cs
+++ b/tests/JeffopolyDeal.Game.Tests/MoneyAndPropertyTests.cs
@@ -77,10 +77,11 @@ namespace JeffopolyDeal.Tests
 
             Assert.Equal(0, h.GetPlaysUsed(p1));
 
-            // Find a card that can be banked (properties can't be played as money)
-            var card = h.GetHand(p1).FirstOrDefault(c =>
-                c.CardType != CardType.Property && c.CardType != CardType.PropertyWildcard);
-            if (card == null) return; // No bankable card — skip
+            // Find a card that can be banked as money (money, action, or rent — not property/wildcard)
+            var card = h.FindCardInHand(p1, CardType.Money)
+                ?? h.FindCardInHand(p1, CardType.Action)
+                ?? h.FindCardInHand(p1, CardType.Rent);
+            if (card == null) return; // extremely rare: hand is all properties
 
             await h.PlayAsMoney(p1, card.Id);
             Assert.Equal(1, h.GetPlaysUsed(p1));

--- a/tests/JeffopolyDeal.Game.Tests/TestGameHarness.cs
+++ b/tests/JeffopolyDeal.Game.Tests/TestGameHarness.cs
@@ -2,6 +2,8 @@ using JeffopolyDeal;
 using JeffopolyDeal.Hubs;
 using JeffopolyDeal.Models;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using System;
 using System.Collections.Concurrent;
@@ -35,7 +37,7 @@ namespace JeffopolyDeal.Tests
         public TestGameHarness(string gameCode = "TEST")
         {
             var hubContext = CreateMockHubContext();
-            _game = new Game(hubContext, gameCode);
+            _game = new Game(hubContext, NullLogger<Game>.Instance, gameCode);
         }
 
         /// <summary>Add a player and return their connectionId.</summary>


### PR DESCRIPTION
## Summary

Adds Application Insights via the Azure Monitor OpenTelemetry distro for both infrastructure monitoring and custom game telemetry.

### Changes

**Infrastructure:**
- `Azure.Monitor.OpenTelemetry.AspNetCore` NuGet package
- OpenTelemetry wired up in `Program.cs` (conditional — only activates when connection string is configured)
- `scripts/setup-appinsights.sh` — Azure CLI script to create App Insights resource + Log Analytics workspace and link to the web app

**Game Telemetry (server-side structured logging via ILogger):**
- **GameStarted** — player count, bot count, theme, full player roster (JSON)
- **CardPlayed** — card type, name, action type, played-as-money, target bot status, rent color/amount
- **ActionResponse** — response type (JustSayNo/Pay), bot status, amount paid
- **GameEnded** — duration, turn count, winner bot status, player/bot counts

All events include a `GameId` for correlation.

**Supporting changes:**
- Added `ILogger<Game>` to `Game` constructor, `ILoggerFactory` to `GameCache`
- Added `_turnNumber` counter and `_gameStopwatch` for duration tracking
- Extracted `SetGameOver()` helper for consistent win-condition handling
- Updated tests with `NullLogger`/`NullLoggerFactory`

**Analytics:**
- `docs/kql-queries.md` with 12 ready-to-use KQL queries (games/day, win rates, popular cards, rent analysis, bot vs human patterns, etc.)

### To activate
1. Run `scripts/setup-appinsights.sh` (or create the App Insights resource manually in Azure Portal)
2. The connection string will be set as an App Service setting automatically
3. Deploy — telemetry starts flowing immediately