### PR TITLE
Fix JSN chain showing wrong player name in action modal

### DIFF
--- a/src/JeffopolyDeal.Game/Game.cs
+++ b/src/JeffopolyDeal.Game/Game.cs
@@ -887,6 +887,7 @@ namespace JeffopolyDeal
                     _pendingAction.TargetPlayerIds = new List<string> { _pendingAction.SourcePlayerId };
                     // Swap source and target for the chain
                     _pendingAction.SourcePlayerId = connectionId;
+                    _pendingAction.SourcePlayerName = responder.Name;
                     return;
                 }
             }

--- a/tests/JeffopolyDeal.Game.Tests/JustSayNoTests.cs
+++ b/tests/JeffopolyDeal.Game.Tests/JustSayNoTests.cs
@@ -193,6 +193,30 @@ namespace JeffopolyDeal.Tests
         }
 
         [Fact]
+        public async Task JSN_SourcePlayerName_UpdatedInChain()
+        {
+            var h = new TestGameHarness();
+            var (p1, p2) = await h.SetupTwoPlayerGameAsync();
+            await h.DrawAsync(p1);
+
+            h.PlaceMoneyInBank(p2, 5);
+            var jsn = h.InjectJustSayNo(p2);
+            var dc = h.InjectAction(p1, ActionType.DebtCollector, 3, "Debt Collector");
+
+            await h.PlayCardAsync(p1, dc.Id, new PlayCardRequest { TargetPlayerId = p2 });
+
+            // P2 plays JSN — the pending action should now show P2 as the source
+            await h.RespondAsync(p2, new ActionResponse { PlayJustSayNo = true });
+
+            var pending = h.GetPendingAction(p1);
+            Assert.NotNull(pending);
+            Assert.Equal(PendingActionType.JustSayNoChain, pending!.Type);
+            // SourcePlayerName should be P2's name, not P1's
+            var p2State = h.GetPlayerState(p1, p2);
+            Assert.Equal(p2State!.Name, pending.SourcePlayerName);
+        }
+
+        [Fact]
         public async Task JSN_BlocksRent_OnlyForThatPlayer()
         {
             var h = new TestGameHarness();


### PR DESCRIPTION
When someone played Just Say No, the SourcePlayerName on the pending action wasn't updated, so the target player saw text like 'You played Just Say No' instead of the other player's name.

**Fix:** Update SourcePlayerName alongside SourcePlayerId when swapping source/target in the JSN chain.

**Test:** Added JSN_SourcePlayerName_UpdatedInChain test verifying the name is correct after a JSN is played.