### PR TITLE
Add Bicep infrastructure template and game analytics workbook

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -84,6 +84,7 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
     Application_Type: 'web'
     WorkspaceResourceId: logAnalytics.id
     IngestionMode: 'LogAnalytics'
+    DisableIpMasking: true
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,109 @@
+// ──────────────────────────────────────────────────────────────
+// Jeffopoly Deal — Azure Infrastructure
+//
+// Deploys all resources needed for the app:
+//   - App Service Plan (B1 Windows)
+//   - Web App (.NET 10, WebSockets for SignalR)
+//   - Log Analytics Workspace
+//   - Application Insights (OpenTelemetry)
+//   - Game Analytics Workbook
+//
+// Usage:
+//   az deployment group create \
+//     --resource-group jeffopolydeal \
+//     --template-file infra/main.bicep
+// ──────────────────────────────────────────────────────────────
+
+@description('Azure region for primary resources (App Service)')
+param appLocation string = 'westus3'
+
+@description('Azure region for monitoring resources (App Insights + Log Analytics)')
+param monitoringLocation string = 'westus2'
+
+@description('App Service Plan SKU')
+param planSku string = 'B1'
+
+// ── App Service Plan ─────────────────────────────────────────
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: 'asp-jeffopolydeal'
+  location: appLocation
+  kind: 'app'
+  sku: {
+    name: planSku
+    tier: planSku == 'B1' ? 'Basic' : 'Standard'
+    capacity: 1
+  }
+}
+
+// ── Web App ──────────────────────────────────────────────────
+
+resource webApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: 'jeffopolydeal'
+  location: appLocation
+  properties: {
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    siteConfig: {
+      netFrameworkVersion: 'v10.0'
+      webSocketsEnabled: true
+      http20Enabled: true
+      ftpsState: 'FtpsOnly'
+      minTlsVersion: '1.2'
+      use32BitWorkerProcess: true
+      appSettings: [
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          value: appInsights.properties.ConnectionString
+        }
+      ]
+    }
+  }
+}
+
+// ── Log Analytics Workspace ──────────────────────────────────
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: 'jeffopolydeal-logs'
+  location: monitoringLocation
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+// ── Application Insights ─────────────────────────────────────
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: 'jeffopolydeal-appinsights'
+  location: monitoringLocation
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalytics.id
+    IngestionMode: 'LogAnalytics'
+  }
+}
+
+// ── Game Analytics Workbook ──────────────────────────────────
+
+resource workbook 'Microsoft.Insights/workbooks@2022-04-01' = {
+  name: guid('jeffopolydeal-game-analytics')
+  location: monitoringLocation
+  kind: 'shared'
+  properties: {
+    displayName: 'Jeffopoly Deal - Game Analytics'
+    category: 'workbook'
+    sourceId: appInsights.id
+    version: '1.0'
+    serializedData: loadTextContent('workbook.json')
+  }
+}
+
+// ── Outputs ──────────────────────────────────────────────────
+
+output webAppUrl string = 'https://${webApp.properties.defaultHostName}'
+output appInsightsConnectionString string = appInsights.properties.ConnectionString
+output workbookId string = workbook.id

--- a/infra/workbook.json
+++ b/infra/workbook.json
@@ -59,12 +59,37 @@
         "size": 3,
         "queryType": 0,
         "resourceType": "microsoft.insights/components",
-        "visualization": "tiles",
-        "tileSettings": {
-          "showBorder": false
-        }
+        "visualization": "table"
       },
       "name": "summary-tiles"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## \ud83d\udc64 Player Leaderboard"
+      },
+      "name": "player-stats-header"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let games = traces\n| where timestamp {TimeRange}\n| where message startswith \"GameStarted\"\n| extend d = parse_json(tostring(customDimensions))\n| extend GameId = tostring(d.GameId), PlayerList = parse_json(tostring(d.Players))\n| mv-expand p = PlayerList\n| extend PlayerName = tostring(p.Name), IsBot = tobool(p.IsBot)\n| project GameId, PlayerName, IsBot;\nlet wins = traces\n| where timestamp {TimeRange}\n| where message startswith \"GameEnded\"\n| extend ed = parse_json(tostring(customDimensions))\n| project GameId = tostring(ed.GameId), WinnerName = tostring(ed.WinnerName), WinnerIsBot = tobool(ed.WinnerIsBot);\ngames\n| join kind=leftouter wins on GameId\n| summarize\n    GamesPlayed = dcount(GameId),\n    Wins = dcountif(GameId, PlayerName == WinnerName),\n    Losses = dcountif(GameId, isnotempty(WinnerName) and PlayerName != WinnerName),\n    InProgress = dcountif(GameId, isempty(WinnerName))\n    by PlayerName, IsBot\n| extend WinRate = iff(Wins + Losses > 0, strcat(tostring(round(100.0 * Wins / (Wins + Losses), 0)), \"%\"), \"-\")\n| extend Player = strcat(PlayerName, iff(IsBot, \" \ud83e\udd16\", \"\"))\n| project Player, GamesPlayed, Wins, Losses, InProgress, WinRate\n| order by GamesPlayed desc",
+        "size": 0,
+        "title": "Player Stats",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "table",
+        "gridSettings": {
+          "sortBy": [
+            {
+              "itemKey": "GamesPlayed",
+              "sortOrder": 2
+            }
+          ]
+        }
+      },
+      "name": "player-stats"
     },
     {
       "type": 3,
@@ -88,10 +113,7 @@
         "title": "\u23f1\ufe0f Game Duration & Turns",
         "queryType": 0,
         "resourceType": "microsoft.insights/components",
-        "visualization": "tiles",
-        "tileSettings": {
-          "showBorder": false
-        }
+        "visualization": "table"
       },
       "name": "duration-stats"
     },
@@ -127,7 +149,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "requests\n| where timestamp {TimeRange}\n| where name contains \"GameHub\"\n| extend City = client_City, Country = client_CountryOrRegion, IP = client_IP\n| summarize Requests=count(), LastSeen=max(timestamp) by Country, City, IP\n| order by LastSeen desc",
+        "query": "let playerIps = requests\n| where timestamp {TimeRange}\n| where name contains \"GameHub\"\n| extend IP = client_IP\n| distinct IP, client_City, client_CountryOrRegion;\nlet playerNames = traces\n| where timestamp {TimeRange}\n| where message startswith \"GameStarted\"\n| extend d = parse_json(tostring(customDimensions))\n| extend PlayerList = parse_json(tostring(d.Players))\n| mv-expand p = PlayerList\n| where tobool(p.IsBot) == false\n| summarize PlayerName = take_any(tostring(p.Name)) by placeholder = 1;\nrequests\n| where timestamp {TimeRange}\n| where name contains \"GameHub\"\n| extend City = client_City, Country = client_CountryOrRegion, IP = client_IP\n| summarize Requests=count(), LastSeen=max(timestamp) by Country, City, IP\n| order by LastSeen desc",
         "size": 0,
         "title": "Players by Location & IP",
         "queryType": 0,
@@ -193,7 +215,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"GameStarted\"\n| extend d = parse_json(tostring(customDimensions))\n| join kind=leftouter (\n    traces\n    | where message startswith \"GameEnded\"\n    | extend ed = parse_json(tostring(customDimensions))\n    | project GameId=tostring(ed.GameId), Duration=strcat(tostring(toint(todouble(ed.DurationSeconds))), \"s\"), Turns=tostring(ed.TurnCount), Winner=tostring(ed.WinnerName), WinnerIsBot=tostring(ed.WinnerIsBot)\n) on $left.tostring(d.GameId) == $right.GameId\n| project Timestamp=timestamp, GameId=tostring(d.GameId), GameCode=tostring(d.GameCode), Players=toint(d.PlayerCount), Bots=toint(d.BotCount), Duration=coalesce(Duration, \"in progress\"), Turns=coalesce(Turns, \"-\"), Winner=coalesce(Winner, \"-\")\n| order by Timestamp desc",
+        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"GameStarted\"\n| extend d = parse_json(tostring(customDimensions))\n| extend GameId = tostring(d.GameId)\n| extend PlayerList = parse_json(tostring(d.Players))\n| mv-apply p = PlayerList on (\n    summarize PlayerNames = strcat_array(make_list(strcat(tostring(p.Name), iff(tobool(p.IsBot), \" \ud83e\udd16\", \"\"))), \", \")\n)\n| join kind=leftouter (\n    traces\n    | where message startswith \"GameEnded\"\n    | extend ed = parse_json(tostring(customDimensions))\n    | extend GameId = tostring(ed.GameId)\n    | project GameId, Duration=strcat(tostring(toint(todouble(ed.DurationSeconds))), \"s\"), Turns=tostring(ed.TurnCount), Winner=tostring(ed.WinnerName), WinnerIsBot=tostring(ed.WinnerIsBot)\n) on GameId\n| project Timestamp=timestamp, GameId, GameCode=tostring(d.GameCode), PlayerNames, Duration=coalesce(Duration, \"in progress\"), Turns=coalesce(Turns, \"-\"), Winner=coalesce(Winner, \"-\")\n| order by Timestamp desc",
         "size": 0,
         "title": "All Games",
         "queryType": 0,
@@ -205,10 +227,23 @@
               "itemKey": "Timestamp",
               "sortOrder": 2
             }
-          ]
+          ],
+          "rowSelection": {
+            "type": "single",
+            "selectedColumns": [
+              "GameId"
+            ]
+          }
         },
-        "exportFieldName": "GameId",
-        "exportParameterName": "SelectedGameId"
+        "exportFieldName": "SelectedGameId",
+        "exportParameterName": "SelectedGameId",
+        "exportedParameters": [
+          {
+            "fieldName": "GameId",
+            "parameterName": "SelectedGameId",
+            "parameterType": 1
+          }
+        ]
       },
       "name": "game-list"
     },
@@ -228,13 +263,18 @@
           "value": ""
         }
       },
-      "name": "game-result"
+      "name": "game-result",
+      "conditionalVisibility": {
+        "parameterName": "SelectedGameId",
+        "comparison": "isNotEqualTo",
+        "value": ""
+      }
     },
     {
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "traces\n| where customDimensions.GameId == \"{SelectedGameId}\"\n| extend d = parse_json(tostring(customDimensions))\n| project Timestamp=timestamp, Event=extract(@\"^(\\w+)\", 1, message), Turn=tostring(d.TurnNumber), IsBot=iff(tobool(d.PlayerIsBot), \"\ud83e\udd16\", \"\ud83d\udc64\"), CardType=tostring(d.CardType), CardName=tostring(d.CardName), Action=tostring(d.ActionType), AsMoney=iff(tobool(d.PlayedAsMoney), \"\ud83d\udcb0\", \"\"), Response=tostring(d.ResponseType)\n| order by Timestamp asc",
+        "query": "traces\n| where customDimensions.GameId == \"{SelectedGameId}\"\n| extend d = parse_json(tostring(customDimensions))\n| extend Event = extract(@\"^(\\w+)\", 1, message)\n| extend PlayerName = tostring(d.PlayerName)\n| extend Turn = toint(d.TurnNumber)\n| extend CardInfo = strcat(tostring(d.CardType), iff(isnotempty(d.CardName), strcat(\": \", tostring(d.CardName)), \"\"))\n| extend Label = case(\n    Event == \"GameStarted\", \"\ud83c\udfae Game Started\",\n    Event == \"GameEnded\", strcat(\"\ud83c\udfc6 \", tostring(d.WinnerName), \" wins!\"),\n    Event == \"CardPlayed\", strcat(PlayerName, \" \u2192 \", CardInfo),\n    Event == \"ActionResponse\", strcat(PlayerName, \" \", tostring(d.ResponseType)),\n    Event)\n| project Timestamp=timestamp, Event, Turn, Player=coalesce(PlayerName, \"-\"), IsBot=iff(tobool(d.PlayerIsBot), \"\ud83e\udd16\", \"\ud83d\udc64\"), Label, CardType=tostring(d.CardType), CardName=tostring(d.CardName), Response=tostring(d.ResponseType)\n| order by Timestamp asc",
         "size": 0,
         "title": "\ud83d\udccb Game Timeline: {SelectedGameId}",
         "queryType": 0,
@@ -246,7 +286,12 @@
           "value": ""
         }
       },
-      "name": "game-detail"
+      "name": "game-detail",
+      "conditionalVisibility": {
+        "parameterName": "SelectedGameId",
+        "comparison": "isNotEqualTo",
+        "value": ""
+      }
     }
   ],
   "fallbackResourceIds": [

--- a/infra/workbook.json
+++ b/infra/workbook.json
@@ -1,0 +1,255 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "# \ud83c\udfb2 Jeffopoly Deal \u2014 Game Analytics"
+      },
+      "name": "title"
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "0e88ff18-f43b-4931-841a-992f7dd6e3c2",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 604800000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                {
+                  "durationMs": 3600000
+                },
+                {
+                  "durationMs": 86400000
+                },
+                {
+                  "durationMs": 604800000
+                },
+                {
+                  "durationMs": 2592000000
+                }
+              ]
+            },
+            "label": "Time Range"
+          }
+        ]
+      },
+      "name": "parameters"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## Overview"
+      },
+      "name": "overview-header"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"GameStarted\"\n| extend d = parse_json(tostring(customDimensions))\n| summarize Games=count(), AvgPlayers=round(avg(todouble(d.PlayerCount)),1), AvgBots=round(avg(todouble(d.BotCount)),1)",
+        "size": 3,
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "showBorder": false
+        }
+      },
+      "name": "summary-tiles"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"GameStarted\"\n| summarize Games=count() by bin(timestamp, 1d)\n| order by timestamp asc",
+        "size": 0,
+        "title": "\ud83d\udcc8 Games Per Day",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart"
+      },
+      "name": "games-per-day"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"GameEnded\"\n| extend d = parse_json(tostring(customDimensions))\n| summarize AvgDurationSec=round(avg(todouble(d.DurationSeconds)),0), MedianDurationSec=round(percentile(todouble(d.DurationSeconds),50),0), AvgTurns=round(avg(todouble(d.TurnCount)),0), MedianTurns=round(percentile(todouble(d.TurnCount),50),0), GamesCompleted=count()",
+        "size": 3,
+        "title": "\u23f1\ufe0f Game Duration & Turns",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "showBorder": false
+        }
+      },
+      "name": "duration-stats"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## \ud83c\udf0d Player Locations"
+      },
+      "name": "locations-header"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "requests\n| where timestamp {TimeRange}\n| where name contains \"GameHub\"\n| where client_CountryOrRegion != \"\"\n| summarize Sessions=dcount(client_IP) by client_CountryOrRegion\n| order by Sessions desc",
+        "size": 0,
+        "title": "Players Map",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "map",
+        "mapSettings": {
+          "locInfo": "CountryRegion",
+          "locInfoColumn": "client_CountryOrRegion",
+          "sizeSettings": "Sessions",
+          "sizeAggregation": "Sum",
+          "legendMetric": "Sessions",
+          "legendAggregation": "Sum"
+        }
+      },
+      "name": "player-map"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "requests\n| where timestamp {TimeRange}\n| where name contains \"GameHub\"\n| extend City = client_City, Country = client_CountryOrRegion, IP = client_IP\n| summarize Requests=count(), LastSeen=max(timestamp) by Country, City, IP\n| order by LastSeen desc",
+        "size": 0,
+        "title": "Players by Location & IP",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "table"
+      },
+      "name": "player-locations"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## \ud83d\udcca Win Rates & Card Stats"
+      },
+      "name": "stats-header"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"GameEnded\"\n| extend d = parse_json(tostring(customDimensions))\n| extend WinnerIsBot = tobool(d.WinnerIsBot)\n| summarize Wins=count() by WinnerType=iff(WinnerIsBot, \"\ud83e\udd16 Bot\", \"\ud83d\udc64 Human\")",
+        "size": 1,
+        "title": "Win Rate: Human vs Bot",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "piechart"
+      },
+      "name": "win-rate"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"CardPlayed\"\n| extend d = parse_json(tostring(customDimensions))\n| where tobool(d.PlayedAsMoney) == false\n| extend CardType = tostring(d.CardType), ActionType = tostring(d.ActionType)\n| extend CardLabel = iff(CardType == \"Action\", ActionType, CardType)\n| summarize Count=count() by CardLabel\n| order by Count desc\n| take 15",
+        "size": 1,
+        "title": "Most Played Card Types",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart"
+      },
+      "name": "card-stats"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"ActionResponse\"\n| extend d = parse_json(tostring(customDimensions))\n| extend ResponseType = tostring(d.ResponseType), PlayerIsBot = tobool(d.PlayerIsBot)\n| summarize Count=count() by ResponseType, PlayerType=iff(PlayerIsBot, \"Bot\", \"Human\")\n| order by Count desc",
+        "size": 0,
+        "title": "Action Responses (JSN vs Pay)",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "table"
+      },
+      "name": "action-responses"
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## \ud83c\udfae Game Drill-Down\nClick a game row to see its full timeline."
+      },
+      "name": "games-header"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where timestamp {TimeRange}\n| where message startswith \"GameStarted\"\n| extend d = parse_json(tostring(customDimensions))\n| join kind=leftouter (\n    traces\n    | where message startswith \"GameEnded\"\n    | extend ed = parse_json(tostring(customDimensions))\n    | project GameId=tostring(ed.GameId), Duration=strcat(tostring(toint(todouble(ed.DurationSeconds))), \"s\"), Turns=tostring(ed.TurnCount), Winner=tostring(ed.WinnerName), WinnerIsBot=tostring(ed.WinnerIsBot)\n) on $left.tostring(d.GameId) == $right.GameId\n| project Timestamp=timestamp, GameId=tostring(d.GameId), GameCode=tostring(d.GameCode), Players=toint(d.PlayerCount), Bots=toint(d.BotCount), Duration=coalesce(Duration, \"in progress\"), Turns=coalesce(Turns, \"-\"), Winner=coalesce(Winner, \"-\")\n| order by Timestamp desc",
+        "size": 0,
+        "title": "All Games",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "table",
+        "gridSettings": {
+          "sortBy": [
+            {
+              "itemKey": "Timestamp",
+              "sortOrder": 2
+            }
+          ]
+        },
+        "exportFieldName": "GameId",
+        "exportParameterName": "SelectedGameId"
+      },
+      "name": "game-list"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where customDimensions.GameId == \"{SelectedGameId}\"\n| where message startswith \"GameEnded\"\n| extend d = parse_json(tostring(customDimensions))\n| project Duration=strcat(tostring(toint(todouble(d.DurationSeconds))), \" seconds\"), Turns=tostring(d.TurnCount), Winner=tostring(d.WinnerName), WinnerIsBot=iff(tobool(d.WinnerIsBot), \"\ud83e\udd16 Yes\", \"\ud83d\udc64 No\"), Players=tostring(d.PlayerCount), Bots=tostring(d.BotCount)",
+        "size": 3,
+        "title": "\ud83c\udfc6 Game Result: {SelectedGameId}",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "table",
+        "conditionalVisibility": {
+          "parameterName": "SelectedGameId",
+          "comparison": "isNotEqualTo",
+          "value": ""
+        }
+      },
+      "name": "game-result"
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where customDimensions.GameId == \"{SelectedGameId}\"\n| extend d = parse_json(tostring(customDimensions))\n| project Timestamp=timestamp, Event=extract(@\"^(\\w+)\", 1, message), Turn=tostring(d.TurnNumber), IsBot=iff(tobool(d.PlayerIsBot), \"\ud83e\udd16\", \"\ud83d\udc64\"), CardType=tostring(d.CardType), CardName=tostring(d.CardName), Action=tostring(d.ActionType), AsMoney=iff(tobool(d.PlayedAsMoney), \"\ud83d\udcb0\", \"\"), Response=tostring(d.ResponseType)\n| order by Timestamp asc",
+        "size": 0,
+        "title": "\ud83d\udccb Game Timeline: {SelectedGameId}",
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "table",
+        "conditionalVisibility": {
+          "parameterName": "SelectedGameId",
+          "comparison": "isNotEqualTo",
+          "value": ""
+        }
+      },
+      "name": "game-detail"
+    }
+  ],
+  "fallbackResourceIds": [
+    "/subscriptions/16086fa9-229c-4bfd-9b92-cc388be37f40/resourceGroups/jeffopolydeal/providers/microsoft.insights/components/jeffopolydeal-appinsights"
+  ]
+}

--- a/src/JeffopolyDeal.Game/Game.cs
+++ b/src/JeffopolyDeal.Game/Game.cs
@@ -464,8 +464,8 @@ namespace JeffopolyDeal
                 // Telemetry: CardPlayed
                 var targetIsBot = request.TargetPlayerId != null && SmartBotAI.IsBot(request.TargetPlayerId);
                 _logger.LogInformation(
-                    "CardPlayed {GameId} {TurnNumber} {PlayerIsBot} {CardType} {CardName} {ActionType} {PlayedAsMoney} {TargetPlayerIsBot} {RentColor} {RentAmount}",
-                    _gameId, _turnNumber, SmartBotAI.IsBot(player.ConnectionId),
+                    "CardPlayed {GameId} {TurnNumber} {PlayerName} {PlayerIsBot} {CardType} {CardName} {ActionType} {PlayedAsMoney} {TargetPlayerIsBot} {RentColor} {RentAmount}",
+                    _gameId, _turnNumber, player.Name, SmartBotAI.IsBot(player.ConnectionId),
                     card.CardType.ToString(), card.Name, card.ActionKind?.ToString(),
                     request.PlayAsMoney, targetIsBot,
                     request.RentColor?.ToString(), _pendingAction?.Amount);
@@ -915,8 +915,8 @@ namespace JeffopolyDeal
             var responderPlayer = _players.FirstOrDefault(p => p.ConnectionId == connectionId);
             var responseType = response.PlayJustSayNo ? "JustSayNo" : "Pay";
             _logger.LogInformation(
-                "ActionResponse {GameId} {TurnNumber} {ResponseType} {PlayerIsBot} {AmountPaid}",
-                _gameId, _turnNumber, responseType,
+                "ActionResponse {GameId} {TurnNumber} {PlayerName} {ResponseType} {PlayerIsBot} {AmountPaid}",
+                _gameId, _turnNumber, responderPlayer?.Name, responseType,
                 SmartBotAI.IsBot(connectionId),
                 response.PaymentCardIds?.Count ?? 0);
 


### PR DESCRIPTION
## Summary

Codifies all Azure resources as Bicep infrastructure-as-code and adds a game analytics workbook (already deployed).

### `infra/main.bicep`
Defines all Azure resources:
- **App Service Plan** (B1 Windows)
- **Web App** (.NET 10, WebSockets, HTTPS-only)
- **Log Analytics Workspace** (30-day retention)
- **Application Insights** (OpenTelemetry, linked to Log Analytics)
- **Game Analytics Workbook** (loaded from workbook.json)

Auto-wires the App Insights connection string to the Web App.

### `infra/workbook.json`
Dashboard sections:
- 📈 Games per day chart
- ⏱️ Game duration & turn stats
- 🌍 Player locations map + IP table
- 📊 Win rate pie chart (human vs bot)
- 🃏 Most played card types & action responses
- 🎮 Game list with click-to-drill-down timeline

### Usage
```bash
az deployment group create --resource-group jeffopolydeal --template-file infra/main.bicep
```

The workbook has already been deployed and is visible in the Azure Portal under Application Insights → Workbooks.